### PR TITLE
Correção #55

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -94,7 +94,7 @@ class ReservaController extends Controller
             $reserva->parent_id = $reserva->id;
             $reserva->save();
 
-            $inicio = Carbon::createFromFormat('d/m/Y', $validated['data']);
+            $inicio = Carbon::createFromFormat('d/m/Y', $validated['data'])->addDays(1);
             $fim = Carbon::createFromFormat('d/m/Y', $validated['repeat_until']);
 
             $period = CarbonPeriod::between($inicio, $fim);


### PR DESCRIPTION
Iniciar a repetição no dia após a primeira reserva resolveu o problema das reservas duplicadas no primeiro dia.