### PR TITLE
Implementações para uma nova versão do sistema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ yarn-error.log
 *.swp
 composer.lock
 /public/vendor/
+
+.lando.yml
+Dockerfile.custom

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -7,6 +7,7 @@ use App\Models\Categoria;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Uspdev\Replicado\Pessoa;
+use App\Utils\ReplicadoUtils;
 
 class CategoriaController extends Controller
 {
@@ -48,8 +49,11 @@ class CategoriaController extends Controller
      */
     public function show(Categoria $categoria)
     {
+        $sigla_unidade = ReplicadoUtils::dumpUnidade(config('salas.codUnidade'), ['sglund']);
+
         return view('categoria.show', [
             'categoria' => $categoria,
+            'sigla_unidade' => $sigla_unidade[0]['sglund']
         ]);
     }
 

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -128,12 +128,15 @@ class CategoriaController extends Controller
                 ->with('alert-danger', 'Número USP inválido');
         }
 
-        // Cria um objeto User para $pessoa
-        $user = User::firstOrCreate([
-            'codpes' => $pessoa['codpes'],
-            'name' => $pessoa['nompes'],
-            'email' => Pessoa::emailusp($pessoa['codpes']),
-        ]);
+        if(count(User::where('codpes', $pessoa['codpes'])->get()) == 0)
+        {
+            $user = User::findOrCreateFromReplicado($pessoa['codpes']);
+            if (!($user instanceof \App\Models\User)) {
+                return redirect()->back()->withErrors(['codpes' => $user]);
+            }
+        }else{
+            $user = User::firstWhere('codpes', $pessoa['codpes']);
+        }
 
         // não pode existir na tabela categoria_users uma instância
         // com o user_id e a categoria_id solicitados.

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -143,6 +143,15 @@ class CategoriaController extends Controller
         return redirect("/categorias/{$categoria->id}");
     }
 
+    public function alterarVinculos(Request $request, Categoria $categoria){
+
+        $categoria->vinculos = $request->input('vinculo');
+        $categoria->save();
+
+        request()->session()->flash('alert-success', "Vínculos cadastrados em {$categoria->nome} alterados.");
+        return redirect()->route('categorias.show', ['categoria' => $categoria->id]);
+    }
+
     public function removeUser(Request $request, Categoria $categoria, User $user)
     {
         $this->authorize('admin');

--- a/app/Http/Controllers/FinalidadeController.php
+++ b/app/Http/Controllers/FinalidadeController.php
@@ -47,17 +47,6 @@ class FinalidadeController extends Controller
     }
 
     /**
-     * Display the specified resource.
-     *
-     * @param  \App\Models\Finalidade  $finalidade
-     * @return \Illuminate\Http\Response
-     */
-    public function show(Finalidade $finalidade)
-    {
-        //
-    }
-
-    /**
      * Show the form for editing the specified resource.
      *
      * @param  \App\Models\Finalidade  $finalidade

--- a/app/Http/Controllers/FinalidadeController.php
+++ b/app/Http/Controllers/FinalidadeController.php
@@ -88,6 +88,9 @@ class FinalidadeController extends Controller
      */
     public function destroy(Finalidade $finalidade)
     {
-        //
+        $finalidade->delete();
+
+        return redirect()->route('finalidades.index')
+            ->with('alert-success', 'Finalidade excluída com sucesso.');
     }
 }

--- a/app/Http/Controllers/FinalidadeController.php
+++ b/app/Http/Controllers/FinalidadeController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Finalidade;
+use Illuminate\Http\Request;
+
+class FinalidadeController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return view('settings.finalidades.index');
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Finalidade  $finalidade
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Finalidade $finalidade)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\Finalidade  $finalidade
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Finalidade $finalidade)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\Finalidade  $finalidade
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, Finalidade $finalidade)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Finalidade  $finalidade
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Finalidade $finalidade)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/FinalidadeController.php
+++ b/app/Http/Controllers/FinalidadeController.php
@@ -65,19 +65,24 @@ class FinalidadeController extends Controller
      */
     public function edit(Finalidade $finalidade)
     {
-        //
+        return view('settings.finalidades.edit', compact('finalidade'));
     }
 
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\FinalidadeRequest  $request
      * @param  \App\Models\Finalidade  $finalidade
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, Finalidade $finalidade)
+    public function update(FinalidadeRequest $request, Finalidade $finalidade)
     {
-        //
+        $validated = $request->validated();
+
+        $finalidade->update($validated);
+
+        return redirect()->route('finalidades.index')
+            ->with('alert-success', 'Finalidade atualizada com sucesso.');
     }
 
     /**

--- a/app/Http/Controllers/FinalidadeController.php
+++ b/app/Http/Controllers/FinalidadeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\FinalidadeRequest;
 use App\Models\Finalidade;
 use Illuminate\Http\Request;
 
@@ -14,7 +15,9 @@ class FinalidadeController extends Controller
      */
     public function index()
     {
-        return view('settings.finalidades.index');
+        $finalidades = Finalidade::all();
+
+        return view('settings.finalidades.index', compact('finalidades'));
     }
 
     /**
@@ -24,18 +27,23 @@ class FinalidadeController extends Controller
      */
     public function create()
     {
-        //
+        return view('settings.finalidades.create');
     }
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \Illuminate\Http\Requests\FinalidadeRequest  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(FinalidadeRequest $request)
     {
-        //
+        $validated = $request->validated();
+
+        $finalidade = Finalidade::create($validated);
+
+        return redirect()->route('finalidades.index')
+            ->with('alert-success', 'Finalidade criada com sucesso.');
     }
 
     /**

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -55,8 +55,19 @@ class ReservaController extends Controller
             $categoria_id = auth()->user()->categorias->map(function ($item, $key) {
                 return $item->id;
             });
-            $categorias = Categoria::with('salas.recursos')->find($categoria_id);
-        }
+            $categorias_list = Categoria::with('salas.recursos')->find($categoria_id);
+
+            $categorias_eca = $categorias_usp = collect();
+
+            if (Gate::allows('senhaunica.docente') || Gate::allows('senhaunica.servidor') || Gate::allows('senhaunica.estagiario'))
+                $categorias_eca = Categoria::where('vinculos', 1)->orWhere('vinculos', 2)->get();
+
+            elseif (Gate::allows('senhaunica.docenteusp') || Gate::allows('senhaunica.servidorusp') || Gate::allows('senhaunica.estagiariousp'))
+                $categorias_usp = Categoria::where('vinculos', 2)->get();
+
+        } 
+
+        $categorias = $categorias_list->merge($categorias_eca, $categorias_usp);
 
         return view('reserva.create', [
             'irmaos' => false,

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -276,4 +276,20 @@ class ReservaController extends Controller
         }
         
     }
+
+    /**
+     * Muda o status da reserva para 'aprovada'.
+     * 
+     * @param \App\Reserva $reserva
+     * 
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function aprovar(Reserva $reserva) {
+       $this->authorize('responsavel', $reserva->sala->id);
+       
+       $reserva->status = 'aprovada';
+       $reserva->save();
+
+       return redirect()->route('reservas.show', $reserva->id);
+    }
 }

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -60,10 +60,10 @@ class ReservaController extends Controller
 
             $categorias_eca = $categorias_usp = new Collection();
 
-            if (Gate::allows('senhaunica.docente') || Gate::allows('senhaunica.servidor') || Gate::allows('senhaunica.estagiario'))
+            if (Gate::allows('pessoa.unidade'))
                 $categorias_eca = Categoria::where('vinculos', 1)->orWhere('vinculos', 2)->get();
 
-            elseif (Gate::allows('senhaunica.docenteusp') || Gate::allows('senhaunica.servidorusp') || Gate::allows('senhaunica.estagiariousp'))
+            elseif (Gate::allows('pessoa.usp'))
                 $categorias_usp = Categoria::where('vinculos', 2)->get();
 
             $categorias = new Collection();

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Gate;
 use App\Mail\CreateReservaMail;
 use App\Mail\DeleteReservaMail;
 use App\Mail\UpdateReservaMail;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Mail;
 
 class ReservaController extends Controller
@@ -57,7 +58,7 @@ class ReservaController extends Controller
             });
             $categorias_list = Categoria::with('salas.recursos')->find($categoria_id);
 
-            $categorias_eca = $categorias_usp = collect();
+            $categorias_eca = $categorias_usp = new Collection();
 
             if (Gate::allows('senhaunica.docente') || Gate::allows('senhaunica.servidor') || Gate::allows('senhaunica.estagiario'))
                 $categorias_eca = Categoria::where('vinculos', 1)->orWhere('vinculos', 2)->get();
@@ -65,7 +66,11 @@ class ReservaController extends Controller
             elseif (Gate::allows('senhaunica.docenteusp') || Gate::allows('senhaunica.servidorusp') || Gate::allows('senhaunica.estagiariousp'))
                 $categorias_usp = Categoria::where('vinculos', 2)->get();
 
-            $categorias = $categorias_list->merge($categorias_eca, $categorias_usp);
+            $categorias = new Collection();
+            $categorias = $categorias->merge($categorias_list);
+            $categorias = $categorias->merge($categorias_eca);
+            $categorias = $categorias->merge($categorias_usp);
+
         } 
 
         return view('reserva.create', [

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -300,7 +300,7 @@ class ReservaController extends Controller
      * @return \Illuminate\Http\RedirectResponse
      */
     public function aprovar(Reserva $reserva) {
-       $this->authorize('responsavel', $reserva->sala->id);
+       $this->authorize('responsavel', $reserva->sala);
        
        $reserva->status = 'aprovada';
        $reserva->save();

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -65,9 +65,8 @@ class ReservaController extends Controller
             elseif (Gate::allows('senhaunica.docenteusp') || Gate::allows('senhaunica.servidorusp') || Gate::allows('senhaunica.estagiariousp'))
                 $categorias_usp = Categoria::where('vinculos', 2)->get();
 
+            $categorias = $categorias_list->merge($categorias_eca, $categorias_usp);
         } 
-
-        $categorias = $categorias_list->merge($categorias_eca, $categorias_usp);
 
         return view('reserva.create', [
             'irmaos' => false,

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -15,6 +15,7 @@ use Illuminate\Support\Facades\Gate;
 use App\Mail\CreateReservaMail;
 use App\Mail\DeleteReservaMail;
 use App\Mail\UpdateReservaMail;
+use App\Models\Finalidade;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Mail;
 
@@ -73,11 +74,14 @@ class ReservaController extends Controller
 
         } 
 
+        $finalidades = Finalidade::all();
+        
         return view('reserva.create', [
             'irmaos' => false,
             'reserva' => new Reserva(),
             'settings' => $settings,
             'categorias' => $categorias,
+            'finalidades' => $finalidades,
         ]);
     }
 

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -95,6 +95,14 @@ class ReservaController extends Controller
 
         $this->authorize('members', $validated['sala_id']);
 
+        if(Sala::find($validated['sala_id'])->aprovacao)
+        {
+            $validated['status'] = 'pendente';
+            $mensagem = "Reserva(s) enviada(s) para análise com sucesso.";
+        }
+        else 
+            $mensagem = "Reserva(s) realizada(s) com sucesso.";
+
         $reserva = Reserva::create($validated);
         $created = '';
         if (array_key_exists('repeat_days', $validated) && array_key_exists('repeat_until', $validated)) {
@@ -120,7 +128,7 @@ class ReservaController extends Controller
         Mail::queue(new CreateReservaMail($reserva));
 
         return redirect("/reservas/{$reserva->id}")
-            ->with('alert-success', "Reserva(s) realizada(s) com sucesso. <ul>{$created}</ul>");
+            ->with('alert-success', $mensagem . " <ul>{$created}</ul>");
     }
 
     /**

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -157,6 +157,7 @@ class ReservaController extends Controller
     public function edit(Reserva $reserva, GeneralSettings $settings)
     {
         $this->authorize('owner', $reserva);
+        $this->authorize('reserva.editar', $reserva);
 
         if (Gate::allows('admin')) {
             $categorias = Categoria::with('salas.recursos')->get();

--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -317,6 +317,6 @@ class ReservaController extends Controller
             $reserva->save();
        }
 
-       return redirect()->route('reservas.show', $reserva->id);
+       return redirect()->route('reservas.show', $reserva->id)->with('alert-success', 'Reserva aprovada com sucesso.');
     }
 }

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ResponsavelController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -40,6 +40,12 @@ class ResponsavelController extends Controller
     public function destroy(Responsavel $responsavel){
         $this->authorize('admin');
 
+        // Se tiver apenas um responsável altera a sala para não precisar de aprovação ao deletar este único responsável.
+        if(count($responsavel->sala->responsaveis) == 1){
+            $responsavel->sala->aprovacao = 0;
+            $responsavel->sala->save();
+        }
+
         $responsavel->delete();
 
         return back()->with('alert-success', 'Responsável removido.');

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -2,9 +2,47 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Responsavel;
+use App\Models\Sala;
+use App\Models\User;
 use Illuminate\Http\Request;
+use Uspdev\Replicado\Pessoa;
 
 class ResponsavelController extends Controller
 {
-    //
+    public function store(Request $request){
+        $this->authorize('admin');
+
+        $codpes = $request->input('codpes');
+        $sala = Sala::find($request->input('sala'));
+
+        if(!User::where('codpes', $codpes))
+        {
+            $user = new User();
+            $user->name = Pessoa::retornarNome($codpes);
+            $user->email = Pessoa::retornarEmailUsp($codpes);
+            $user->codpes = $codpes;
+            $user->save();
+        }else{
+            $user = User::firstWhere('codpes', $codpes);
+        }
+
+        $responsavel = new Responsavel();
+        $responsavel->sala_id = $sala->id;
+        $responsavel->user_id = $user->id;
+        $responsavel->save();
+
+        $sala->aprovacao = 1;
+        $sala->save();
+
+        return redirect()->route('salas.edit',['sala' => $request->input('sala'), 'responsaveis' => $sala->responsaveis])->with('alert-success', $user->name.' adicionado como responsável.');
+    }
+
+    public function destroy(Responsavel $responsavel){
+        $this->authorize('admin');
+
+        $responsavel->delete();
+
+        return back()->with('alert-success', 'Responsável removido.');
+    }
 }

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -18,11 +18,10 @@ class ResponsavelController extends Controller
 
         if(count(User::where('codpes', $codpes)->get()) == 0)
         {
-            $user = new User();
-            $user->name = Pessoa::retornarNome($codpes);
-            $user->email = Pessoa::email($codpes);
-            $user->codpes = $codpes;
-            $user->save();
+            $user = User::findOrCreateFromReplicado($codpes);
+            if (!($user instanceof \App\Models\User)) {
+                return redirect()->back()->withErrors(['codpes' => $user]);
+            }
         }else{
             $user = User::firstWhere('codpes', $codpes);
         }

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -16,11 +16,11 @@ class ResponsavelController extends Controller
         $codpes = $request->input('codpes');
         $sala = Sala::find($request->input('sala'));
 
-        if(!User::where('codpes', $codpes))
+        if(count(User::where('codpes', $codpes)->get()) == 0)
         {
             $user = new User();
             $user->name = Pessoa::retornarNome($codpes);
-            $user->email = Pessoa::retornarEmailUsp($codpes);
+            $user->email = Pessoa::email($codpes);
             $user->codpes = $codpes;
             $user->save();
         }else{

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -120,6 +120,7 @@ class SalaController extends Controller
             'sala' => $sala,
             'categorias' => Categoria::all(),
             'recursos' => $recursos,
+            'responsaveis' => $sala->responsaveis
         ]);
     }
 
@@ -135,6 +136,9 @@ class SalaController extends Controller
         $this->authorize('admin');
 
         $validated = $request->validated();
+
+        if($validated['aprovacao'] && count($sala->responsaveis) < 1)
+            return redirect()->route('salas.edit', ['sala' => $sala->id])->with('alert-danger', 'A sala deve ter ao menos um responsável se necessitar de aprovação para reserva.');
 
         $sala->update($validated);
 

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -83,6 +83,7 @@ class SalaController extends Controller
                 [
                     'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? config('salas.cores.semFinalidade')),
                     'url' => '/reservas/'.$reserva->id,
+                    'textColor' => 'black'
                 ],
             );
         }

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -81,7 +81,7 @@ class SalaController extends Controller
                 $reserva->fim,
                 0, //optionally, you can specify an event ID,
                 [
-                    'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : $reserva->cor,
+                    'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? config('salas.cores.semFinalidade')),
                     'url' => '/reservas/'.$reserva->id,
                 ],
             );

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -81,7 +81,7 @@ class SalaController extends Controller
                 $reserva->fim,
                 0, //optionally, you can specify an event ID,
                 [
-                    'color' => $reserva->cor,
+                    'color' => $reserva->status == 'pendente' ? config('salas.corPendente') : $reserva->cor,
                     'url' => '/reservas/'.$reserva->id,
                 ],
             );

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\SalaRequest;
 use App\Models\Categoria;
+use App\Models\Finalidade;
 use App\Models\Recurso;
 use App\Models\Reserva;
 use App\Models\Sala;
@@ -94,10 +95,13 @@ class SalaController extends Controller
                 'defaultView' => 'agendaWeek',
         ]);
 
+        $finalidades = Finalidade::all();
+
         return view('sala.show', [
             'sala' => $sala,
             'calendar' => $calendar,
             'recursos' => Recurso::all(),
+            'finalidades' => $finalidades
             ]);
     }
 

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -81,7 +81,7 @@ class SalaController extends Controller
                 $reserva->fim,
                 0, //optionally, you can specify an event ID,
                 [
-                    'color' => $reserva->status == 'pendente' ? config('salas.corPendente') : $reserva->cor,
+                    'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : $reserva->cor,
                     'url' => '/reservas/'.$reserva->id,
                 ],
             );

--- a/app/Http/Requests/FinalidadeRequest.php
+++ b/app/Http/Requests/FinalidadeRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class FinalidadeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'legenda' => 'required',
+            'cor' => 'required'
+        ];
+    }
+}

--- a/app/Http/Requests/ReservaRequest.php
+++ b/app/Http/Requests/ReservaRequest.php
@@ -39,7 +39,7 @@ class ReservaRequest extends FormRequest
             'nome' => 'required',
             'horario_inicio' => 'required|date_format:G:i|',
             'horario_fim' => 'required|date_format:G:i|after:horario_inicio|',
-            'cor' => 'nullable',
+            'finalidade_id' => 'required|integer',
             'sala_id' => ['required', Rule::in(Sala::pluck('id')->toArray())],
             'descricao' => 'nullable',
             'repeat_until' => ['required_with:repeat_days', 'nullable', 'date_format:d/m/Y'],

--- a/app/Http/Requests/SalaRequest.php
+++ b/app/Http/Requests/SalaRequest.php
@@ -28,6 +28,7 @@ class SalaRequest extends FormRequest
             'categoria_id' => 'required',
             'capacidade'   => 'required|integer',
             'recursos'     => 'nullable',
+            'aprovacao'    => 'required|integer'
         ];
     }
 

--- a/app/Mail/SolicitarReservaMail.php
+++ b/app/Mail/SolicitarReservaMail.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Reserva;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class SolicitarReservaMail extends Mailable
+{
+    use Queueable, SerializesModels;
+    private $reserva;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct(Reserva $reserva)
+    {
+        $this->reserva = $reserva;
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        $user = User::find($this->reserva->user_id);
+        return $this->view('emails.create_reserva')
+                    ->subject('Novo pedido de reserva solicitado - Sistema Reserva de Salas')
+                    ->with([
+                        'reserva' => $this->reserva,
+                    ]);
+    }
+}

--- a/app/Models/Finalidade.php
+++ b/app/Models/Finalidade.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Finalidade extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Finalidade.php
+++ b/app/Models/Finalidade.php
@@ -8,4 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 class Finalidade extends Model
 {
     use HasFactory;
+
+    protected $guarded = ['id'];
 }

--- a/app/Models/Reserva.php
+++ b/app/Models/Reserva.php
@@ -103,4 +103,8 @@ class Reserva extends Model implements Auditable
     {
         return $this->parent_id === $this->id;
     }
+
+    public function finalidade(){
+        return $this->belongsTo(Finalidade::class);
+    }
 }

--- a/app/Models/Responsavel.php
+++ b/app/Models/Responsavel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Responsavel extends Model
+{
+    use HasFactory;
+
+    protected $table = 'responsaveis';
+    protected $guarded = ['id'];
+
+    public function salas()
+    {
+        return $this->belongsToMany(Sala::class);
+    }
+}

--- a/app/Models/Responsavel.php
+++ b/app/Models/Responsavel.php
@@ -16,4 +16,9 @@ class Responsavel extends Model
     {
         return $this->belongsToMany(Sala::class);
     }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Sala.php
+++ b/app/Models/Sala.php
@@ -31,4 +31,9 @@ class Sala extends Model implements Auditable
     {
         return $this->belongsTo(Categoria::class);
     }
+
+    public function responsaveis()
+    {
+        return $this->hasMany(Responsavel::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -14,6 +14,8 @@ class User extends Authenticatable
     use Notifiable;
     use HasRoles;
     use HasSenhaunica;
+    use \Spatie\Permission\Traits\HasRoles;
+    use \Uspdev\SenhaunicaSocialite\Traits\HasSenhaunica;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -45,6 +45,11 @@ class AuthServiceProvider extends ServiceProvider
          */
         Gate::define('members', function ($user, $sala_id) {
             if(Gate::allows('admin')) return true;
+
+            if(Gate::allows('pessoa.unidade')) return Sala::find($sala_id)->categoria->vinculos == 1;
+                
+            if(Gate::allows('pessoa.usp')) return Sala::find($sala_id)->categoria->vinculos == 2;
+
             /* o $user está numa categoria que tem a sala_id? */
             $sala = Sala::find($sala_id);
             foreach($user->categorias as $categoria){

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -72,5 +72,18 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('pessoa.usp', function(){
             return Gate::allows('senhaunica.docenteusp') || Gate::allows('senhaunica.servidorusp') || Gate::allows('senhaunica.estagiariousp');
         });
+
+        /**
+         * Pessoas que são responsáveis pela sala em questão.
+         */
+        Gate::define('responsavel', function($user, $sala_id){
+            $sala = Sala::find($sala_id);
+
+            foreach($sala->responsaveis as $responsavel){
+                if($responsavel->user->id == $user->id) return true;
+            }
+
+            return false;
+        });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -77,10 +77,8 @@ class AuthServiceProvider extends ServiceProvider
         /**
          * Pessoas que são responsáveis pela sala em questão.
          */
-        Gate::define('responsavel', function($user, $sala_id){
+        Gate::define('responsavel', function($user, $sala){
             if(Gate::allows('admin')) return true;
-
-            $sala = Sala::find($sala_id);
 
             foreach($sala->responsaveis as $responsavel){
                 if($responsavel->user->id == $user->id) return true;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -81,7 +81,7 @@ class AuthServiceProvider extends ServiceProvider
             if(Gate::allows('admin')) return true;
 
             foreach($sala->responsaveis as $responsavel){
-                if($responsavel->user->id == $user->id) return true;
+                if($responsavel->id == $user->id) return true;
             }
 
             return false;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\Reserva;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
 use App\Models\Sala;
@@ -84,6 +85,21 @@ class AuthServiceProvider extends ServiceProvider
             foreach($sala->responsaveis as $responsavel){
                 if($responsavel->user->id == $user->id) return true;
             }
+
+            return false;
+        });
+
+        /**
+         * Reservas que podem ser editadas.
+         */
+        Gate::define('reserva.editar', function($user, $reserva){
+            if(Gate::allows('admin')) return true;
+
+            // Se a sala não necessita de aprovação retorna true.
+            if(!$reserva->sala->aprovacao) return true;
+
+            // Se a sala necessita de aprovação e está pendente retorna true.
+            if($reserva->sala->aprovacao && $reserva->status == 'pendente') return true;
 
             return false;
         });

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -52,5 +52,19 @@ class AuthServiceProvider extends ServiceProvider
             }
             return false;
         });
+
+        /**
+         * Pessoas que possuem um dos três vínculos (Docente, Servidor ou Estagiário) ligadas à unidade.
+         */
+        Gate::define('pessoa.unidade', function(){
+            return Gate::allows('senhaunica.docente') || Gate::allows('senhaunica.servidor') || Gate::allows('senhaunica.estagiario');
+        });
+
+        /**
+         * Pessoas que possuem um dos três vínculos (Docente, Servidor ou Estagiário) ligadas à USP.
+         */
+        Gate::define('pessoa.usp', function(){
+            return Gate::allows('senhaunica.docenteusp') || Gate::allows('senhaunica.servidorusp') || Gate::allows('senhaunica.estagiariousp');
+        });
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -77,6 +77,8 @@ class AuthServiceProvider extends ServiceProvider
          * Pessoas que são responsáveis pela sala em questão.
          */
         Gate::define('responsavel', function($user, $sala_id){
+            if(Gate::allows('admin')) return true;
+
             $sala = Sala::find($sala_id);
 
             foreach($sala->responsaveis as $responsavel){

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -46,15 +46,16 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('members', function ($user, $sala_id) {
             if(Gate::allows('admin')) return true;
 
-            if(Gate::allows('pessoa.unidade')) return Sala::find($sala_id)->categoria->vinculos == 1;
-                
-            if(Gate::allows('pessoa.usp')) return Sala::find($sala_id)->categoria->vinculos == 2;
-
             /* o $user está numa categoria que tem a sala_id? */
             $sala = Sala::find($sala_id);
             foreach($user->categorias as $categoria){
                 if( $sala->categoria->id == $categoria->id ) return true;
             }
+
+            if(Gate::allows('pessoa.unidade')) return Sala::find($sala_id)->categoria->vinculos == 1;
+                
+            if(Gate::allows('pessoa.usp')) return Sala::find($sala_id)->categoria->vinculos == 2;
+
             return false;
         });
 

--- a/app/Utils/ReplicadoUtils.php
+++ b/app/Utils/ReplicadoUtils.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Utils;
+
+use Uspdev\Replicado\DB;
+
+class ReplicadoUtils
+{
+
+    /**
+     * Método que recebe o código da unidade e retorna todos os campos da tabela UNIDADE referente ao código de unidade passado.
+     * Se $fields também for passado busca apenas os campos solicitados neste.
+     * 
+     * @param Integer $codundclg
+     * @param array $fields
+     * @return Mixed
+     */
+    public static function dumpUnidade($codundclg, $fields = ['*']){
+        $columns = implode(',', $fields);
+        $query = "SELECT {$columns} FROM UNIDADE u WHERE u.codund IN (:codundclg)"; 
+
+        $params = [
+            'codundclg' => $codundclg
+        ];
+        
+        return DB::fetchAll($query, $params);
+    }
+
+}

--- a/composer.lock
+++ b/composer.lock
@@ -6562,16 +6562,16 @@
         },
         {
             "name": "uspdev/senhaunica-socialite",
-            "version": "4.3.1",
+            "version": "4.3.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/uspdev/senhaunica-socialite.git",
-                "reference": "773129848337aa97220f13bae9bb4febd1d8da3f"
+                "reference": "bd96e18480acb020a397391eed96a6617f7c2d60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/uspdev/senhaunica-socialite/zipball/773129848337aa97220f13bae9bb4febd1d8da3f",
-                "reference": "773129848337aa97220f13bae9bb4febd1d8da3f",
+                "url": "https://api.github.com/repos/uspdev/senhaunica-socialite/zipball/bd96e18480acb020a397391eed96a6617f7c2d60",
+                "reference": "bd96e18480acb020a397391eed96a6617f7c2d60",
                 "shasum": ""
             },
             "require": {
@@ -6579,7 +6579,7 @@
                 "laravel/socialite": "^5.0",
                 "php": ">=7.1.3",
                 "socialiteproviders/manager": "^3.4.2 | ^4.0",
-                "spatie/laravel-permission": "^4.2"
+                "spatie/laravel-permission": "^4.2 | ^5.0"
             },
             "type": "library",
             "extra": {
@@ -6590,12 +6590,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Uspdev\\SenhaunicaSocialite\\": "src/"
-                },
                 "files": [
                     "src/helpers.php"
-                ]
+                ],
+                "psr-4": {
+                    "Uspdev\\SenhaunicaSocialite\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -6612,9 +6612,9 @@
             "homepage": "https://github.com/uspdev/senhaunica-socialite",
             "support": {
                 "issues": "https://github.com/uspdev/senhaunica-socialite/issues",
-                "source": "https://github.com/uspdev/senhaunica-socialite/tree/4.3.1"
+                "source": "https://github.com/uspdev/senhaunica-socialite/tree/4.3.7"
             },
-            "time": "2021-11-29T11:42:02+00:00"
+            "time": "2023-09-12T00:05:00+00:00"
         },
         {
             "name": "vlucas/phpdotenv",
@@ -9319,5 +9319,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -6371,7 +6371,7 @@
         },
         {
             "name": "uspdev/cache",
-            "version": "0.7.3",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/uspdev/cache.git",
@@ -6406,7 +6406,7 @@
             "homepage": "https://github.com/uspdev/cache",
             "support": {
                 "issues": "https://github.com/uspdev/cache/issues",
-                "source": "https://github.com/uspdev/cache/tree/0.7.3"
+                "source": "https://github.com/uspdev/cache/tree/1.0.0"
             },
             "time": "2021-04-07T23:14:52+00:00"
         },
@@ -6512,31 +6512,33 @@
         },
         {
             "name": "uspdev/replicado",
-            "version": "1.10.7",
+            "version": "1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/uspdev/replicado.git",
-                "reference": "2a732cf07da00ff8234775474313ef80a0c4a0e3"
+                "reference": "64f9bac68647ead390457c40519e07b5a7586e89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/uspdev/replicado/zipball/2a732cf07da00ff8234775474313ef80a0c4a0e3",
-                "reference": "2a732cf07da00ff8234775474313ef80a0c4a0e3",
+                "url": "https://api.github.com/repos/uspdev/replicado/zipball/64f9bac68647ead390457c40519e07b5a7586e89",
+                "reference": "64f9bac68647ead390457c40519e07b5a7586e89",
                 "shasum": ""
             },
             "require": {
                 "ext-pdo_dblib": "*",
-                "illuminate/support": "^5 || ^6 || ^7 || ^8",
-                "monolog/monolog": "^1.25 || ^2",
+                "illuminate/collections": "^8 || ^9",
+                "monolog/monolog": "^2 || ^3",
                 "php": ">=7.0",
-                "uspdev/cache": "^0.7"
+                "uspdev/cache": "^1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.0 || ^9.0",
-                "vlucas/phpdotenv": "^5.2"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "helpers/helpers.php"
+                ],
                 "psr-4": {
                     "Uspdev\\Replicado\\": "src"
                 }
@@ -6556,9 +6558,9 @@
             "homepage": "https://github.com/uspdev/replicado",
             "support": {
                 "issues": "https://github.com/uspdev/replicado/issues",
-                "source": "https://github.com/uspdev/replicado/tree/1.10.7"
+                "source": "https://github.com/uspdev/replicado/tree/1.18.0"
             },
-            "time": "2022-02-11T19:00:47+00:00"
+            "time": "2023-06-14T18:28:12+00:00"
         },
         {
             "name": "uspdev/senhaunica-socialite",

--- a/config/laravel-usp-theme.php
+++ b/config/laravel-usp-theme.php
@@ -67,20 +67,7 @@ $right_menu = [
         'can' => 'admin',
     ],
     [
-        'text' => '<i class="fas fa-users"></i>',
-        'title' => 'Pessoas',
-        'target' => '_blank',
-        'url' => config('app.url').'/users',
-        'align' => 'right',
-        'can' => 'admin',
-    ],
-    [
-        'text' => '<i class="fas fa-user-secret"></i>',
-        'title' => 'Login As',
-        'target' => '_blank',
-        'url' => config('app.url').'/loginas',
-        'align' => 'right',
-        'can' => 'admin',
+        'key' => 'senhaunica-socialite'
     ],
     [
         'text' => '<i class="fas fa-hard-hat"></i>',

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,132 @@
+<?php
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+    ],
+
+    /*
+     * When set to true, the required permission names are added to the exception
+     * message. This could be considered an information leak in some contexts, so
+     * the default setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to the exception
+     * message. This could be considered an information leak in some contexts, so
+     * the default setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/config/salas.php
+++ b/config/salas.php
@@ -7,5 +7,8 @@ return [
     |--------------------------------------------------------------------------
     */
     'codUnidade' => env('REPLICADO_CODUNDCLG', 8),
-    'corPendente' => '#FFB540'
+    'cores' => [
+        'pendente' => '#FFB540',
+        'semFinalidade' => '#BDBDBD'
+    ]
 ];

--- a/config/salas.php
+++ b/config/salas.php
@@ -6,4 +6,5 @@ return [
     | Arquivo padrão de configuração do salas
     |--------------------------------------------------------------------------
     */
+    'codUnidade' => env('REPLICADO_CODUNDCLG', 8)
 ];

--- a/config/salas.php
+++ b/config/salas.php
@@ -7,5 +7,5 @@ return [
     |--------------------------------------------------------------------------
     */
     'codUnidade' => env('REPLICADO_CODUNDCLG', 8),
-    'corPendente' => '#ffa41c'
+    'corPendente' => '#FFB540'
 ];

--- a/config/salas.php
+++ b/config/salas.php
@@ -6,5 +6,6 @@ return [
     | Arquivo padrão de configuração do salas
     |--------------------------------------------------------------------------
     */
-    'codUnidade' => env('REPLICADO_CODUNDCLG', 8)
+    'codUnidade' => env('REPLICADO_CODUNDCLG', 8),
+    'corPendente' => '#ffa41c'
 ];

--- a/database/factories/ReservaFactory.php
+++ b/database/factories/ReservaFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Models\Reserva;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\DB;
 
 class ReservaFactory extends Factory
 {
@@ -21,12 +22,14 @@ class ReservaFactory extends Factory
      */
     public function definition()
     {
+        $finalidades_ids = DB::table('finalidades')->pluck('id');
+
         return [
             'nome' => $this->faker->word(),
             'data' => $this->faker->date($format = 'd/m/Y'),
             'horario_inicio' => $this->faker->time($format = 'H:i'),
             'horario_fim' => $this->faker->time($format = 'H:i'),
-            'cor' => $this->faker->hexcolor,
+            'finalidade_id' => $this->faker->randomElement($finalidades_ids),
             'sala_id' => $this->faker->numberBetween($min = 1, $max = 5),
             'descricao' => $this->faker->sentence(4),
             'user_id' => 1,

--- a/database/migrations/2023_09_12_105208_update_senhaunica_users_table.php
+++ b/database/migrations/2023_09_12_105208_update_senhaunica_users_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateSenhaunicaUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Caso necessário, ajuste para refletir suas necessidades
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('password')->nullable()->change(); # deixar opcional
+            if (!Schema::hasColumn('users', 'codpes')) {
+                    // https://stackoverflow.com/questions/20822159/laravel-migration-with-sqlite-cannot-add-a-not-null-column-with-default-value-n
+                    if ('sqlite' === Schema::connection($this->getConnection())->getConnection()->getDriverName()) {
+                    $table->integer('codpes')->nullable();
+                } else {
+                    $table->integer('codpes');
+                }
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Não vamos remover as colunas para preservar os dados
+        //$table->dropColumn('codpes');
+    }
+}

--- a/database/migrations/2023_09_15_153702_add_vinculos_to_categorias_table.php
+++ b/database/migrations/2023_09_15_153702_add_vinculos_to_categorias_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddVinculosToCategoriasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('categorias', function (Blueprint $table) {
+            $table->tinyInteger('vinculos')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('categorias', function (Blueprint $table) {
+            $table->dropColumn('vinculos');
+        });
+    }
+}

--- a/database/migrations/2023_09_22_153221_create_responsaveis_table.php
+++ b/database/migrations/2023_09_22_153221_create_responsaveis_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateResponsaveisTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('responsaveis', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sala_id')->constrained();
+            $table->foreignId('user_id')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('responsaveis');
+    }
+}

--- a/database/migrations/2023_09_22_153221_create_responsaveis_table.php
+++ b/database/migrations/2023_09_22_153221_create_responsaveis_table.php
@@ -15,8 +15,8 @@ class CreateResponsaveisTable extends Migration
     {
         Schema::create('responsaveis', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('sala_id')->constrained();
-            $table->foreignId('user_id')->constrained();
+            $table->foreignId('sala_id')->constrained()->onDelete('cascade');
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_09_25_170555_add_aprovacao_column_to_salas_table.php
+++ b/database/migrations/2023_09_25_170555_add_aprovacao_column_to_salas_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAprovacaoColumnToSalasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('salas', function (Blueprint $table) {
+            $table->tinyInteger('aprovacao')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('salas', function (Blueprint $table) {
+            $table->dropColumn('aprovacao');
+        });
+    }
+}

--- a/database/migrations/2023_09_29_100208_add_status_column_to_reservas_table.php
+++ b/database/migrations/2023_09_29_100208_add_status_column_to_reservas_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStatusColumnToReservasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            $table->string('status')->default('aprovada');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+}

--- a/database/migrations/2023_10_04_165304_create_finalidades_table.php
+++ b/database/migrations/2023_10_04_165304_create_finalidades_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFinalidadesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('finalidades', function (Blueprint $table) {
+            $table->id();
+            $table->string('legenda');
+            $table->string('cor');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('finalidades');
+    }
+}

--- a/database/migrations/2023_10_04_165304_create_finalidades_table.php
+++ b/database/migrations/2023_10_04_165304_create_finalidades_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schema;
 
 class CreateFinalidadesTable extends Migration
@@ -19,6 +20,12 @@ class CreateFinalidadesTable extends Migration
             $table->string('cor');
             $table->timestamps();
         });
+
+        // Popula instâncias padrão de finalidades no momento da migration.
+        Artisan::call('db:seed', [
+            '--class' => 'FinalidadeSeeder',
+            '--force' => true // Para rodar o seeder em produção
+        ]);
     }
 
     /**

--- a/database/migrations/2023_10_06_102606_update_reservas_table.php
+++ b/database/migrations/2023_10_06_102606_update_reservas_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateReservasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            $table->foreignId('finalidade_id')->nullable()->constrained();
+            $table->dropColumn('cor');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('finalidade_id');
+            $table->string('cor')->default('#408AD2'); // Define um cor arbitrária para as reservas aprovadas no caso de reverter a migration.
+        });
+    }
+}

--- a/database/migrations/2023_10_06_102606_update_reservas_table.php
+++ b/database/migrations/2023_10_06_102606_update_reservas_table.php
@@ -14,7 +14,7 @@ class UpdateReservasTable extends Migration
     public function up()
     {
         Schema::table('reservas', function (Blueprint $table) {
-            $table->foreignId('finalidade_id')->nullable()->constrained();
+            $table->foreignId('finalidade_id')->nullable()->constrained()->nullOnDelete();
             $table->dropColumn('cor');
         });
     }

--- a/database/seeders/FinalidadeSeeder.php
+++ b/database/seeders/FinalidadeSeeder.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class FinalidadeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('finalidades')->insert([
+            'legenda' => 'Graduação',
+            'cor' => '#FFFCB7',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Pós-Graduação',
+            'cor' => '#C7F3BA',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Especialização',
+            'cor' => '#BAE3F3',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Extensão',
+            'cor' => '#EFDFCF',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Defesa',
+            'cor' => '#EEC9F1',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Qualificação',
+            'cor' => '#CCCC99',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Reunião',
+            'cor' => '#F78B83',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+
+        DB::table('finalidades')->insert([
+            'legenda' => 'Evento',
+            'cor' => '#FBCCAC',
+            'created_at' => now(),
+            'updated_at' => now()
+        ]);
+    }
+}

--- a/database/seeders/ReservaSeeder.php
+++ b/database/seeders/ReservaSeeder.php
@@ -19,7 +19,7 @@ class ReservaSeeder extends Seeder
             'data' => '14/01/2021',
             'horario_inicio' => '12:00',
             'horario_fim' => '13:00',
-            'cor' => '#aea1ff',
+            'finalidade_id' => 1,
             'sala_id' => 1,
             'descricao' => 'Aula de Política III do ano de 2020.',
             'user_id' => 1,

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ O gerenciamento pelo vínculo é referente somente aos vínculos de Docente, Ser
 
 - **USP**: todos os docentes, servidores e estagiários que entrarem com a senha única no sistema poderão realizar reservas na categoria.
 - **Unidade**: todos os docentes, servidores e estagiários que entrarem com a senha única e pertecerem à unidade que o sistema estiver configurado poderão realizar reservas na categoria.
+  (A unidade é mostrada com base na variável de ambiente `REPLICADO_CODUNDCLG` do `.env`)
 - **Nenhum**: somente as pessoas cadastradas manualmente poderão realizar reservas na categoria.
 
 # Finalidades

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,48 @@
 # Sistema Salas
 
-Sistema em Laravel para o gerenciamento dos eventos de um instituto de acordo com as salas e horários disponíveis.
+Sistema em Laravel para o gerenciamento dos eventos de uma unidade de acordo com as salas e horários disponíveis.
 
 # Recursos
 
 - Visualização do calendário de reservas de cada sala (semanal, diário e mensal)
 - Busca pelas reservas filtrando por categoria, data e título
 - Administração dos usuários permitidos para reservar em um grupo de salas através das Categorias
+- Configurar se a sala precisa ou não de aprovação para o pedido de reserva
+- Administração dos usuários responsáveis por cada sala, que gerenciarão os pedidos de reservas para as salas que precisam de aprovação
+- Administração das finalidades para as reservas
 - Criação e edição de reservas em massa caso haja repetição do evento
 - Validação para que reservas não sejam cadastradas caso haja sobreposição de data, horário e sala
+- 
+# Gerenciando Pessoas Cadastradas na Categoria
+
+As pessoas cadastradas nas categorias são aquelas que poderão realizar reservas na categoria em questão. Para cada categoria é possível gerenciar as pessoas cadastradas de duas formas: pelo número USP ou pelo vínculo com a unidade em questão.
+
+Pelo número USP é necessário inserir manualmente o número USP da pessoa desejada na aba de edição categoria, e ela será cadastrada na categoria possibilitando realizar reservas.
+
+O gerenciamento pelo vínculo é referente somente aos vínculos de Docente, Servidor e Estagiário, e possui três opções:
+
+- **USP**: todos os docentes, servidores e estagiários que entrarem com a senha única no sistema poderão realizar reservas na categoria.
+- **Unidade**: todos os docentes, servidores e estagiários que entrarem com a senha única e pertecerem à unidade que o sistema estiver configurado poderão realizar reservas na categoria.
+- **Nenhum**: somente as pessoas cadastradas manualmente poderão realizar reservas na categoria.
+
+# Finalidades
+
+Por padrão o sistema é instalado com as seguintes finalidades para as reservas:
+
+- Graduação
+- Pós-Graduação
+- Especialização
+- Extensão
+- Defesa
+- Qualificação
+- Reunião
+- Evento
+
+Mas todo gerenciamento de finalidades como adicionar, editar ou excluir, pode ser feito na aba de configurações. Permitindo a customização das finalidades para que melhor se adéque à unidade que for utilizar o sistema.
+
+# Realizando Reservas com Aprovação
+
+Na aba de edição da sala é possível gerenciar os responsáveis pela sala através do número USP, bem como configurar se a sala necessita de aprovação ou não para a reserva. No caso de precisar de aprovação, quando uma pessoa autorizada tentar realizar uma reserva na sala, a reserva será feita com um *status* de pendente, um e-mail será enviado para os responsáveis da sala e estes devem analisar o pedido de reserva no sistema, aprovando ou recusando.
 
 # Como subir a aplicação
 ## Instalação
@@ -17,7 +51,7 @@ Sistema em Laravel para o gerenciamento dos eventos de um instituto de acordo co
 composer install
 cp .env.example .env
 php artisan key:generate
-php artisan migrate:fresh --seed
+php artisan migrate
 ```
 
 ## Para acessar a aplicação

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Sistema em Laravel para o gerenciamento dos eventos de uma unidade de acordo com
 - Administração das finalidades para as reservas
 - Criação e edição de reservas em massa caso haja repetição do evento
 - Validação para que reservas não sejam cadastradas caso haja sobreposição de data, horário e sala
-- 
+ 
 # Gerenciando Pessoas Cadastradas na Categoria
 
 As pessoas cadastradas nas categorias são aquelas que poderão realizar reservas na categoria em questão. Para cada categoria é possível gerenciar as pessoas cadastradas de duas formas: pelo número USP ou pelo vínculo com a unidade em questão.
@@ -44,6 +44,7 @@ Mas todo gerenciamento de finalidades como adicionar, editar ou excluir, pode se
 
 Na aba de edição da sala é possível gerenciar os responsáveis pela sala através do número USP, bem como configurar se a sala necessita de aprovação ou não para a reserva. No caso de precisar de aprovação, quando uma pessoa autorizada tentar realizar uma reserva na sala, a reserva será feita com um *status* de pendente, um e-mail será enviado para os responsáveis da sala e estes devem analisar o pedido de reserva no sistema, aprovando ou recusando.
 
+
 # Como subir a aplicação
 ## Instalação
 
@@ -51,7 +52,17 @@ Na aba de edição da sala é possível gerenciar os responsáveis pela sala atr
 composer install
 cp .env.example .env
 php artisan key:generate
+```
+**Para ambiente de produção:**
+
+```bash
 php artisan migrate
+```
+
+**Para ambiente de desenvolvimento:**
+
+```bash
+php artisan migrate:fresh --seed
 ```
 
 ## Para acessar a aplicação
@@ -59,3 +70,13 @@ php artisan migrate
 ```sh
 php artisan serve
 ```
+# Histórico
+
+Este sistema foi transferido da FFLCH para o USPDev.
+
+- 15/09/2023: Permitindo selecionar qual o nível de vínculo que poderá realizar reserva na categoria.
+- 27/09/2023: Permitindo configurar necessidade de aprovação da sala e administração dos responsáveis.
+- 10/10/2023: Removendo coluna `cor` da tabela `reservas` e implementando a opção de finalidades.
+- 17/10/2023: Arrumando envio de e-mail no momento de solicitar e aprovar/recusar reservas.
+- 18/10/2023: Implementando legenda de finalidades no calendário da sala.
+- 18/10/2023: Arrumando *seeders*.

--- a/resources/views/categoria/partials/fields.blade.php
+++ b/resources/views/categoria/partials/fields.blade.php
@@ -15,6 +15,8 @@
         </div>
     </div>
     <div class="card-body">
+    @include('categoria.partials.vinculos')
+    <br>
     @include('categoria.partials.addForm')
     <br>
     @include('categoria.partials.pesIndex')

--- a/resources/views/categoria/partials/vinculos.blade.php
+++ b/resources/views/categoria/partials/vinculos.blade.php
@@ -1,0 +1,34 @@
+<div class="card">
+    <div class="card-header">
+      <b>Vínculos cadastrados em {{ $categoria->nome }}</b>
+    </div>
+    <div class="card-body">
+        <form method="POST" action="{{route('alterar-vinculos', ['categoria' => $categoria])}}">
+            @csrf
+            <p>
+                Referente apenas aos vínculos de <b>Docentes, Servidores e Estagiários</b>:
+            </p>
+            <div class="form-check mb-3">
+                <input class="form-check-input radio-box" type="radio" name="vinculo" value="2" id="usp" {{$categoria->vinculos == 2 ? "checked" : ""}}>
+                <label class="form-check-label" for="usp">
+                  <b>USP</b> (Todas as pessoas que entrem com senha única)
+                </label>
+            </div>
+            
+            <div class="form-check mb-3">
+                <input class="form-check-input radio-box" type="radio" name="vinculo" value="1" id="eca" {{$categoria->vinculos == 1 ? "checked" : ""}}>
+                <label class="form-check-label" for="eca">
+                  <b>ECA</b> (Todas as pessoas da unidade)
+                </label>
+            </div>
+            
+            <div class="form-check mb-3">
+                <input class="form-check-input radio-box" type="radio" name="vinculo" value="0" id="nenhum" {{$categoria->vinculos == 0 ? "checked" : ""}}>
+                <label class="form-check-label" for="nenhum">
+                  <b>Nenhum</b> (Apenas as pessoas cadastradas manualmente)
+                </label>
+            </div>
+            <button class="btn btn-success" type="submit">Salvar</button>
+        </form>
+    </div>
+</div>

--- a/resources/views/categoria/partials/vinculos.blade.php
+++ b/resources/views/categoria/partials/vinculos.blade.php
@@ -18,7 +18,7 @@
             <div class="form-check mb-3">
                 <input class="form-check-input radio-box" type="radio" name="vinculo" value="1" id="eca" {{$categoria->vinculos == 1 ? "checked" : ""}}>
                 <label class="form-check-label" for="eca">
-                  <b>ECA</b> (Todas as pessoas da unidade)
+                  <b>{{$sigla_unidade}}</b> (Todas as pessoas da unidade)
                 </label>
             </div>
             

--- a/resources/views/emails/create_reserva.blade.php
+++ b/resources/views/emails/create_reserva.blade.php
@@ -1,8 +1,13 @@
-<h2>Nova(s) <a href="{{route('reservas.show', ['reserva' => $reserva->id])}}">reserva(s)</a> adicionada(s) no site <a href="{{route('home')}}" >{{route('home')}}</a></h2>
+@if ($reserva->status == 'pendente')
+    <h2>Novo pedido de <a href="{{route('reservas.show', ['reserva' => $reserva->id])}}">reserva(s)</a> solicitada(s) no site <a href="{{route('home')}}" >{{route('home')}}</a></h2>
+@else
+    <h2>Nova(s) <a href="{{route('reservas.show', ['reserva' => $reserva->id])}}">reserva(s)</a> adicionada(s) no site <a href="{{route('home')}}" >{{route('home')}}</a></h2>
+@endif
 
 <h3><b>Título:</b> {{$reserva->nome}} </h3>
 <p><b>Horário:</b> {{$reserva->horario_inicio}} </p>
 <p><b>Sala:</b> {{$reserva->sala->nome}} </p>
+<p><b>Finalidade:</b> {{$reserva->finalidade->legenda}} </p>
 
 @if($reserva->irmaos())
     <p><b>Datas:</b>
@@ -13,6 +18,8 @@
 @else
     <p><b>Data:</b> {{$reserva->data}} </p>
 @endif
+
+<p><b>Status da reserva:</b> {{ucfirst($reserva->status)}} </p>
 
 <br>
 <p>Mensagem automática do sistema de reserva de salas: {{route('home')}}</p>

--- a/resources/views/emails/create_reserva.blade.php
+++ b/resources/views/emails/create_reserva.blade.php
@@ -1,4 +1,4 @@
-<h2>Nova(s) <a href="https://salas.fflch.usp.br/reservas/{{ $reserva->id }}">reserva(s)</a> adicionada(s) no site <a href="https://salas.fflch.usp.br/" >salas.fflch.usp.br</a></h2>
+<h2>Nova(s) <a href="{{route('reservas.show', ['reserva' => $reserva->id])}}">reserva(s)</a> adicionada(s) no site <a href="{{route('home')}}" >{{route('home')}}</a></h2>
 
 <h3><b>Título:</b> {{$reserva->nome}} </h3>
 <p><b>Horário:</b> {{$reserva->horario_inicio}} </p>
@@ -15,4 +15,4 @@
 @endif
 
 <br>
-<p>Mensagem automática do sistema de reserva de salas: https://salas.fflch.usp.br</p>
+<p>Mensagem automática do sistema de reserva de salas: {{route('home')}}</p>

--- a/resources/views/emails/delete_reserva.blade.php
+++ b/resources/views/emails/delete_reserva.blade.php
@@ -1,4 +1,4 @@
-<h2>Nova exclusão de reserva(s) de sala no site <a href="https://salas.fflch.usp.br/" >salas.fflch.usp.br</a>.</h2>
+<h2>Nova exclusão de reserva(s) de sala no site <a href="{{route('home')}}" >{{route('home')}}</a>.</h2>
 
 <h3><b>Título:</b> {{$reserva->nome}} </h3>
 <p><b>Horário:</b> {{$reserva->horario_inicio}} </p>
@@ -16,4 +16,4 @@
 
 <br>
 
-<p>Mensagem automática do sistema de reserva de salas: https://salas.fflch.usp.br</p>
+<p>Mensagem automática do sistema de reserva de salas: {{route('home')}}</p>

--- a/resources/views/emails/delete_reserva.blade.php
+++ b/resources/views/emails/delete_reserva.blade.php
@@ -3,6 +3,7 @@
 <h3><b>Título:</b> {{$reserva->nome}} </h3>
 <p><b>Horário:</b> {{$reserva->horario_inicio}} </p>
 <p><b>Sala:</b> {{$reserva->sala->nome}} </p>
+<p><b>Finalidade:</b> {{$reserva->finalidade->legenda}} </p>
 
 @if($reserva->irmaos())
     <p><b>Datas:</b>

--- a/resources/views/emails/update_reserva.blade.php
+++ b/resources/views/emails/update_reserva.blade.php
@@ -1,4 +1,4 @@
-<h2>Reserva(s): <a href="https://salas.fflch.usp.br/reservas/{{ $reserva->id }}">{{$reserva->id}}</a> modificada(s) no site <a href="https://salas.fflch.usp.br/" >salas.fflch.usp.br</a></h2>
+<h2>Reserva(s): <a href="{{route('reservas.show', ['reserva' => $reserva->id])}}">{{$reserva->id}}</a> modificada(s) no site <a href="{{route('home')}}" >{{route('home')}}</a></h2>
 
 <h3><b>Título:</b> {{$reserva->nome}} </h3>
 <p><b>Horário:</b> {{$reserva->horario_inicio}} </p>
@@ -16,4 +16,4 @@
 
 <br>
 
-<p>Mensagem automática do sistema de reserva de salas: https://salas.fflch.usp.br</p>
+<p>Mensagem automática do sistema de reserva de salas: {{route('home')}}</p>

--- a/resources/views/emails/update_reserva.blade.php
+++ b/resources/views/emails/update_reserva.blade.php
@@ -3,6 +3,7 @@
 <h3><b>Título:</b> {{$reserva->nome}} </h3>
 <p><b>Horário:</b> {{$reserva->horario_inicio}} </p>
 <p><b>Sala:</b> {{$reserva->sala->nome}} </p>
+<p><b>Finalidade:</b> {{$reserva->finalidade->legenda}} </p>
 
 @if($reserva->irmaos())
     <p><b>Datas:</b>

--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -34,8 +34,9 @@
     <div class="flash-message">
         @foreach (['danger', 'warning', 'success', 'info'] as $msg)
             @if(Session::has('alert-' . $msg))
-                <p class="alert alert-{{ $msg }}">{!! Session::get('alert-' . $msg) !!}
+                <p class="alert alert-{{ $msg }}">
                     <a href="#" class="close" data-dismiss="alert" aria-label="fechar">&times;</a>
+                    {!! Session::get('alert-' . $msg) !!}
                 </p>
             @endif
         @endforeach

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -93,9 +93,13 @@
 
 @if ($reserva->status == 'pendente')
     @can('responsavel', $reserva->sala->id)
+        <form action="{{route('reservas.destroy', $reserva)}}" method="POST" id="form-reserva-recusar" onsubmit="return confirm('Recusar reserva?')">
+            @csrf
+            @method('DELETE')
+        </form>
         <div class="mt-4">
             <a class="btn btn-success" href="{{route('reservas.aprovar', $reserva)}}"><i class="fa fa-check"></i> Aprovar</a>
-            <a class="btn btn-danger"><i class="fa fa-ban"></i> Recusar</a>
+            <button class="btn btn-danger" form="form-reserva-recusar"><i class="fa fa-ban"></i> Recusar</button>
         </div>
     @endcan
 @endif

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -68,7 +68,7 @@
                     <td>{{ $reserva->descricao ?: 'Sem descrição' }}</td>
                     <td>
                         @if(isset($reserva->finalidade))
-                            <div style="background-color: {{  $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? '')}}" class="p-2 mt-n2 rounded">{{$reserva->finalidade->legenda}}</div>
+                            <div style="background-color: {{ $reserva->finalidade->cor }}" class="p-2 mt-n2 rounded">{{$reserva->finalidade->legenda}}</div>
                         @else
                             <div style="background-color: #BDBDBD" class="p-2 mt-n2 rounded">Sem finalidade</div>
                         @endif

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -30,9 +30,11 @@
                 <form action="/reservas/{{  $reserva->id  }}" method="POST">
                     @csrf
                     @method('delete')
-                    <a class="btn btn-success" href="/reservas/{{  $reserva->id  }}/edit" title="Editar">
-                        <i class="fa fa-pen"></i>
-                    </a>
+                    @can('reserva.editar', $reserva)
+                        <a class="btn btn-success" href="/reservas/{{  $reserva->id  }}/edit" title="Editar">
+                            <i class="fa fa-pen"></i>
+                        </a>
+                    @endcan
 
                     <button class="btn btn-danger" type="submit" title="Excluir" 
                         onclick="return confirm('Tem certeza que deseja excluir a(s) reserva(s)?');" >

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -65,7 +65,7 @@
                     </td>
                     <td>{{ $reserva->descricao ?: 'Sem descrição' }}</td>
                     <td>
-                    <div class="rectangle" style="background-color: {{  $reserva->cor ?? ''  }};"></div>
+                    <div class="rectangle" style="background-color: {{  $reserva->status = 'pendente' ? config('salas.corPendente') : ($reserva->cor ?? '')}};"></div>
                     </td>
                 </tr>
             </div>

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -56,7 +56,7 @@
                     <th>Horário</th>
                     <th>Sala</th>
                     <th>Descrição</th>
-                    <th>Cor</th>
+                    <th>Finalidade</th>
                 </tr>
                 <tr>
                     <td>{{ $reserva->user->name }} - {{ $reserva->user->codpes }}</td>
@@ -67,7 +67,11 @@
                     </td>
                     <td>{{ $reserva->descricao ?: 'Sem descrição' }}</td>
                     <td>
-                    <div class="rectangle" style="background-color: {{  $reserva->status == 'pendente' ? config('salas.corPendente') : ($reserva->cor ?? '')}};"></div>
+                        @if(isset($reserva->finalidade))
+                            <div style="background-color: {{  $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? '')}}" class="p-2 mt-n2 rounded">{{$reserva->finalidade->legenda}}</div>
+                        @else
+                            <div style="background-color: #BDBDBD" class="p-2 mt-n2 rounded">Sem finalidade</div>
+                        @endif
                     </td>
                 </tr>
             </div>

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -19,6 +19,12 @@
     }
 </style>
 
+@if ($reserva->status == 'pendente')
+   <div style="background-color: {{config('salas.cores.pendente')}}" class="p-2 mb-2 rounded">
+     Pendente    
+   </div>
+@endif
+
 <div class="card">
     <div class="card-header" id="reserva-header">
         <div>

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -65,7 +65,7 @@
                     </td>
                     <td>{{ $reserva->descricao ?: 'Sem descrição' }}</td>
                     <td>
-                    <div class="rectangle" style="background-color: {{  $reserva->status = 'pendente' ? config('salas.corPendente') : ($reserva->cor ?? '')}};"></div>
+                    <div class="rectangle" style="background-color: {{  $reserva->status == 'pendente' ? config('salas.corPendente') : ($reserva->cor ?? '')}};"></div>
                     </td>
                 </tr>
             </div>
@@ -78,8 +78,8 @@
                     $reservas_array = $reserva->irmaos()->toArray();
                 @endphp
                 
-                @foreach($reservas_array as $key => $reserva)
-                    <a href="/reservas/{{ $reserva['id'] }}">{{ $reserva['data'] }}</a>@if( $key !== count($reservas_array) -1 ),@endif
+                @foreach($reservas_array as $key => $reservaIterator)
+                    <a href="/reservas/{{ $reservaIterator['id'] }}">{{ $reservaIterator['data'] }}</a>@if( $key !== count($reservas_array) -1 ),@endif
                 @endforeach
             </div>
         @endif
@@ -88,3 +88,12 @@
         <br>
     </div>
 </div>
+
+@if ($reserva->status == 'pendente')
+    @can('responsavel', $reserva->sala->id)
+        <div class="mt-4">
+            <a class="btn btn-success" href="{{route('reservas.aprovar', $reserva)}}"><i class="fa fa-check"></i> Aprovar</a>
+            <a class="btn btn-danger"><i class="fa fa-ban"></i> Recusar</a>
+        </div>
+    @endcan
+@endif

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -92,7 +92,7 @@
 </div>
 
 @if ($reserva->status == 'pendente')
-    @can('responsavel', $reserva->sala->id)
+    @can('responsavel', $reserva->sala)
         <form action="{{route('reservas.destroy', $reserva)}}" method="POST" id="form-reserva-recusar" onsubmit="return confirm('Recusar reserva?')">
             @csrf
             @method('DELETE')

--- a/resources/views/reserva/partials/form.blade.php
+++ b/resources/views/reserva/partials/form.blade.php
@@ -24,9 +24,13 @@
                 <input type="text" class="form-control"  name="nome" value="{{  old('nome', $reserva->nome) }}">
             </div>
             <div class="col-sm form-group">
-                <label for="" class="required"><b>Cor</b></label>
+                <label for="" class="required"><b>Finalidade</b></label>
                 <br>
-                <input type="color" class="form-control form-control-color" name="cor" value= "{{ empty($reserva->cor) ? $settings->cor : old('cor', $reserva->cor) }}">
+                <select name="finalidade_id" class="form-control form-select" required>
+                    @foreach ($finalidades as $finalidade)
+                        <option value="{{$finalidade->id}}">{{$finalidade->legenda}}</option>
+                    @endforeach
+                </select>
             </div>
         </div>
 

--- a/resources/views/reserva/partials/table.blade.php
+++ b/resources/views/reserva/partials/table.blade.php
@@ -16,7 +16,7 @@
                 <td>{{ $reserva->horario_inicio }} - {{$reserva->horario_fim}}</td>
                 <td><a href="/salas/{{ $reserva->sala_id }}">{{ $reserva->sala->nome }}</a></td>
                 <td>{{ $reserva->sala->categoria->nome }}</td>
-                <td><div class="dot" style="background-color: {{$reserva->finalidade->cor ?? config('salas.cores.semFinalidade')}};"></div></td>
+                <td><div class="dot" style="background-color: {{$reserva->status == 'pendente' ? config('salas.cores.pendente'): ($reserva->finalidade->cor ?? config('salas.cores.semFinalidade'))}};"></div></td>
                 <td><a href="/reservas/{{ $reserva->id }}">{{ $reserva->nome }}</a></td>
                 <td>Capacidade: {{ $reserva->sala->capacidade  }}</td>
                 <td>{{ $reserva->descricao }}</td>

--- a/resources/views/reserva/partials/table.blade.php
+++ b/resources/views/reserva/partials/table.blade.php
@@ -16,7 +16,7 @@
                 <td>{{ $reserva->horario_inicio }} - {{$reserva->horario_fim}}</td>
                 <td><a href="/salas/{{ $reserva->sala_id }}">{{ $reserva->sala->nome }}</a></td>
                 <td>{{ $reserva->sala->categoria->nome }}</td>
-                <td><div class="dot" style="background-color: {{$reserva->cor}};"></div></td>
+                <td><div class="dot" style="background-color: {{$reserva->finalidade->cor ?? config('salas.cores.semFinalidade')}};"></div></td>
                 <td><a href="/reservas/{{ $reserva->id }}">{{ $reserva->nome }}</a></td>
                 <td>Capacidade: {{ $reserva->sala->capacidade  }}</td>
                 <td>{{ $reserva->descricao }}</td>

--- a/resources/views/sala/edit.blade.php
+++ b/resources/views/sala/edit.blade.php
@@ -1,5 +1,7 @@
 @extends('main')
 @section('content')
+    <form action="{{route('responsaveis.store')}}" method="POST" id='form-add-responsavel'>@csrf</form>
+    <form method="POST" id="form-delete-responsavel">@csrf @method('DELETE')</form>
     <form method="POST" action="/salas/{{ $sala->id }}">
         @csrf
         @method('patch')
@@ -14,5 +16,22 @@
         $(document).ready(function() {
             $('.categorias_select').select2();
         });
+
+       $('.radio-aprovacao').on('click', function(e){
+            if(parseInt($(this).val()))
+                $('#responsavel-box').css('display', 'block');
+            else
+                $('#responsavel-box').css('display', 'none');
+       });
+
+       $('#btn-delete-responsavel').on('click', function(e) {
+            e.preventDefault();
+            let form_delete_responsavel = $('#form-delete-responsavel');
+            let route = '{{route('responsaveis.destroy', ':responsavel')}}';
+            route = route.replace(':responsavel', $(this).data('responsavel'));
+            
+            form_delete_responsavel.attr('action', route);
+            form_delete_responsavel.submit();
+       });
     </script>
 @stop

--- a/resources/views/sala/edit.blade.php
+++ b/resources/views/sala/edit.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <form action="{{route('responsaveis.store')}}" method="POST" id='form-add-responsavel'>@csrf</form>
     <form method="POST" id="form-delete-responsavel">@csrf @method('DELETE')</form>
-    <form method="POST" action="/salas/{{ $sala->id }}">
+    <form method="POST" action="/salas/{{ $sala->id }}" id="form-update-sala">
         @csrf
         @method('patch')
         @include('sala.partials.form', ['title' => "Editar"])
@@ -11,6 +11,7 @@
 
 @section('javascripts_bottom')
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jquery-validation@1.19.5/dist/jquery.validate.min.js"></script>
 
     <script type="text/javascript">
         $(document).ready(function() {
@@ -33,5 +34,19 @@
             form_delete_responsavel.attr('action', route);
             form_delete_responsavel.submit();
        });
+
+       $('#form-update-sala').validate({
+            submitHandler: function(form){
+                if($('#aprovacao-sim').is(':checked') && {{count($sala->responsaveis)}} < 1)
+                    alert("A sala deve ter ao menos um responsável se necessitar de aprovação para reserva.");
+                else
+                    form.submit();
+            },
+            rules: {
+                aprovacao: {
+                    required: true,
+                }
+            }
+       })
     </script>
 @stop

--- a/resources/views/sala/edit.blade.php
+++ b/resources/views/sala/edit.blade.php
@@ -25,14 +25,16 @@
                 $('#responsavel-box').css('display', 'none');
        });
 
-       $('#btn-delete-responsavel').on('click', function(e) {
+       $('.btn-delete-responsavel').on('click', function(e) {
             e.preventDefault();
-            let form_delete_responsavel = $('#form-delete-responsavel');
-            let route = '{{route('responsaveis.destroy', ':responsavel')}}';
-            route = route.replace(':responsavel', $(this).data('responsavel'));
-            
-            form_delete_responsavel.attr('action', route);
-            form_delete_responsavel.submit();
+            if(confirm('Tem certeza que deseja remover ' + $(this).data('responsavel-name') + ' como responsável?')){
+                let form_delete_responsavel = $('#form-delete-responsavel');
+                let route = '{{route('responsaveis.destroy', ':responsavel')}}';
+                route = route.replace(':responsavel', $(this).data('responsavel-id'));
+                
+                form_delete_responsavel.attr('action', route);
+                form_delete_responsavel.submit();
+            }
        });
 
        $('#form-update-sala').validate({

--- a/resources/views/sala/partials/form.blade.php
+++ b/resources/views/sala/partials/form.blade.php
@@ -87,6 +87,8 @@
                     </div>
                 </div>
             </div>
+        @elseif($title == 'Nova')
+            <input type="hidden" name="aprovacao" value="0">
         @endif
         <button type="submit" class="btn btn-success"> Enviar </button>
         <br>

--- a/resources/views/sala/partials/form.blade.php
+++ b/resources/views/sala/partials/form.blade.php
@@ -49,6 +49,45 @@
             </div>
 
         </div>
+        @if ($title == 'Editar')
+            <div class="row">
+                <div class="col-sm form-group">
+                    <b>Necessita de Aprovação?</b>
+                    <div class="form-check">
+                        <input name="aprovacao" type="radio" class="form-check-input radio-aprovacao" id="aprovacao-sim" value="1" {{$sala->aprovacao ? 'checked' : ''}}>
+                        <label for="aprovacao-sim">Sim</label>
+                    </div>
+                    <div class="form-check">
+                        <input name="aprovacao" type="radio" class="form-check-input radio-aprovacao" id="aprovacao-nao" value="0" {{!$sala->aprovacao ? 'checked' : ''}}>
+                        <label for="aprovacao-nao">Não</label>
+                    </div>
+                    <div id="responsavel-box" @if (!$sala->aprovacao) style="display: none" @endif>
+                        <b>Responsáveis</b>
+                        <div class="d-flex flex-inline form-group">
+                            <input name="codpes" type="text" placeholder="Número USP" class="w-25 form-control" id="numero-usp" form="form-add-responsavel" required> 
+                            <input name="sala" type="hidden" value="{{$sala->id}}" form="form-add-responsavel">
+                            <button class="btn btn-success ml-2" id="btn-inserir-responsavel" type="submit" form="form-add-responsavel">Inserir</button>
+                        </div>
+                        <div class="card form-group">
+                            <div class="card-header">Lista de Responsáveis</div>
+                            <ul class="list-group list-group-flush">
+                                @if (count($responsaveis) > 0)
+                                    @foreach ($responsaveis as $responsavel)
+                                        <li class="list-group-item d-inline-flex justify-content-between">{{$responsavel->user->codpes}} - {{$responsavel->user->name}}
+                                            <button id="btn-delete-responsavel" data-responsavel="{{$responsavel->id}}" class="btn btn-danger btn-sm" form="form-delete-responsavel">
+                                                <i class="fa fa-trash" ></i>
+                                            </button>
+                                        </li>
+                                    @endforeach
+                                @else
+                                    <li class="list-group-item">Não há responsáveis cadastrados.</li>
+                                @endif
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endif
         <button type="submit" class="btn btn-success"> Enviar </button>
         <br>
     </div>

--- a/resources/views/sala/partials/form.blade.php
+++ b/resources/views/sala/partials/form.blade.php
@@ -74,7 +74,7 @@
                                 @if (count($responsaveis) > 0)
                                     @foreach ($responsaveis as $responsavel)
                                         <li class="list-group-item d-inline-flex justify-content-between">{{$responsavel->user->codpes}} - {{$responsavel->user->name}}
-                                            <button id="btn-delete-responsavel" data-responsavel="{{$responsavel->id}}" class="btn btn-danger btn-sm" form="form-delete-responsavel">
+                                            <button data-responsavel-name="{{$responsavel->user->name}}" data-responsavel-id="{{$responsavel->id}}" class="btn btn-danger btn-sm btn-delete-responsavel" form="form-delete-responsavel">
                                                 <i class="fa fa-trash" ></i>
                                             </button>
                                         </li>

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -11,7 +11,27 @@
             @include('sala.partials.fields')
         </div>
     </div>
+    <div class="d-flex flex-wrap w-100 justify-content-center mt-3">
+        @foreach ($finalidades as $finalidade)
+            <div class="flex-item rounded" style="background-color: {{$finalidade->cor}}">{{$finalidade->legenda}}</div>
+        @endforeach
+            <div class="flex-item rounded" style="background-color: {{config('salas.cores.pendente')}}">Pendente</div>
+            <div class="flex-item rounded" style="background-color: {{config('salas.cores.semFinalidade')}}">Sem Finalidade</div>
+    </div>
+
     <br><br>
     {!! $calendar->calendar() !!}
     {!! $calendar->script() !!}
 @endsection  
+
+@section('styles')
+@parent
+<style>
+    .flex-item{
+        text-align: center;
+        padding: 5px 20px;
+        margin: 5px;
+        border: 1px solid black;
+    }
+</style>
+@endsection

--- a/resources/views/settings/finalidades/create.blade.php
+++ b/resources/views/settings/finalidades/create.blade.php
@@ -1,0 +1,22 @@
+@extends('main')
+@section('content')
+    <div class="card">
+        <div class="card-header"><b>Adicionar Finalidade</b></div>
+        <div class="card-body">
+            <form action="{{route('finalidades.store')}}" method="POST">
+                @csrf
+                <div class="row">
+                    <div class="form-group col-sm">
+                        <b>Legenda</b>
+                        <input name="legenda" type="text" class="form-control" required>
+                    </div>
+                    <div class="form-group col-sm">
+                        <b>Cor</b>
+                        <input name="cor" type="color" class="form-control form-control-color" title="Escolha a cor da finalidade" required>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-success">Enviar</button>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/settings/finalidades/edit.blade.php
+++ b/resources/views/settings/finalidades/edit.blade.php
@@ -1,0 +1,23 @@
+@extends('main')
+@section('content')
+    <div class="card">
+        <div class="card-header"><b>Editar Finalidade</b></div>
+        <div class="card-body">
+            <form action="{{route('finalidades.update', $finalidade->id)}}" method="POST">
+                @csrf
+                @method('PATCH')
+                <div class="row">
+                    <div class="form-group col-sm">
+                        <b>Legenda</b>
+                        <input name="legenda" type="text" class="form-control" value="{{$finalidade->legenda}}" required>
+                    </div>
+                    <div class="form-group col-sm">
+                        <b>Cor</b>
+                        <input name="cor" type="color" class="form-control form-control-color" title="Escolha a cor da finalidade" value="{{$finalidade->cor}}" required>
+                    </div>
+                </div>
+                <button type="submit" class="btn btn-success">Enviar</button>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/settings/finalidades/index.blade.php
+++ b/resources/views/settings/finalidades/index.blade.php
@@ -1,5 +1,24 @@
 @extends('main')
 @section('content')
-<h2>Finalidades</h2>
+
+<div class="mb-3">
+    <a href="{{route('finalidades.create')}}" class="btn btn-success">Adicionar Finalidade</a>
+</div>
+
+<div class="card">
+    <div class="card-header">
+        Lista de Finalidades
+    </div>
+    <ul class="list-group list-group-flush">
+        @if (count($finalidades) > 0)
+            @foreach ($finalidades as $finalidade)
+                <li class="list-group-item">{{$finalidade->legenda}} - {{$finalidade->cor}}</li>
+            @endforeach
+        @else
+            <li class="list-group-item">Não há finalidades cadastradas.</li>
+        @endif
+    </ul>
+
+</div>
     
 @endsection

--- a/resources/views/settings/finalidades/index.blade.php
+++ b/resources/views/settings/finalidades/index.blade.php
@@ -22,7 +22,33 @@
                         <form action="{{route('finalidades.destroy', $finalidade->id)}}" method="POST">
                             @csrf
                             @method('DELETE')
-                            <button class="btn btn-danger" id="btn-exluir-finalidade" onclick="return confirm('Excluir a finalidade {{$finalidade->legenda}}?')"><i class="fa fa-trash" ></i></button>
+
+                            <!-- Modal Button -->
+                            <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#delete-{{$finalidade->legenda}}-Modal"><i class="fa fa-trash" ></i></button>
+
+                            <!-- Modal -->
+                            <div class="modal fade" id="delete-{{$finalidade->legenda}}-Modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title" id="exampleModalLabel">Excluir a finalidade {{$finalidade->legenda}}?</h5>
+                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                    </button>
+                                </div>
+                                <div class="modal-body">
+                                    <p class="text-justify">
+                                        Se excluir esta finalidade todas as reservas que estiveram com esta finalidade selecionada ficarão sinalizadas da seguinte forma:
+                                    </p>
+                                    <div class="rounded p-2 m-auto w-50" style="background-color: {{config('salas.cores.semFinalidade')}}">Sem finalidade</div>
+                                </div>
+                                <div class="modal-footer">
+                                    <button type="submit" class="btn btn-danger">Excluir</button>
+                                    <button type="button" class="btn btn-light" data-dismiss="modal">Fechar</button>
+                                </div>
+                                </div>
+                            </div>
+                            </div>
                         </form>
                     </div>
                 </li>

--- a/resources/views/settings/finalidades/index.blade.php
+++ b/resources/views/settings/finalidades/index.blade.php
@@ -1,0 +1,5 @@
+@extends('main')
+@section('content')
+<h2>Finalidades</h2>
+    
+@endsection

--- a/resources/views/settings/finalidades/index.blade.php
+++ b/resources/views/settings/finalidades/index.blade.php
@@ -13,14 +13,18 @@
         @if (count($finalidades) > 0)
             @foreach ($finalidades as $finalidade)
                 <li class="list-group-item d-inline-flex justify-content-between align-items-center">
-                    <div style="background-color: {{$finalidade->cor}}" class="py-2 px-4 rounded">
+                    <a href="{{route('finalidades.edit', $finalidade->id)}}" style="background-color: {{$finalidade->cor}}" class="btn px-4 rounded">
                         {{$finalidade->legenda}} 
+                    </a>
+                    <div class="row">
+                        <a href="{{route('finalidades.edit', $finalidade->id)}}" class="btn btn-warning mr-2"><i class="fa fa-pen text-white"></i></a>
+
+                        <form action="{{route('finalidades.destroy', $finalidade->id)}}" method="POST">
+                            @csrf
+                            @method('DELETE')
+                            <button class="btn btn-danger" id="btn-exluir-finalidade" onclick="return confirm('Excluir a finalidade {{$finalidade->legenda}}?')"><i class="fa fa-trash" ></i></button>
+                        </form>
                     </div>
-                    <form action="{{route('finalidades.destroy', $finalidade->id)}}" method="POST">
-                        @csrf
-                        @method('DELETE')
-                        <button class="btn btn-danger" id="btn-exluir-finalidade" onclick="return confirm('Excluir a finalidade {{$finalidade->legenda}}?')"><i class="fa fa-trash" ></i></button>
-                    </form>
                 </li>
             @endforeach
         @else

--- a/resources/views/settings/finalidades/index.blade.php
+++ b/resources/views/settings/finalidades/index.blade.php
@@ -12,7 +12,16 @@
     <ul class="list-group list-group-flush">
         @if (count($finalidades) > 0)
             @foreach ($finalidades as $finalidade)
-                <li class="list-group-item">{{$finalidade->legenda}} - {{$finalidade->cor}}</li>
+                <li class="list-group-item d-inline-flex justify-content-between align-items-center">
+                    <div style="background-color: {{$finalidade->cor}}" class="py-2 px-4 rounded">
+                        {{$finalidade->legenda}} 
+                    </div>
+                    <form action="{{route('finalidades.destroy', $finalidade->id)}}" method="POST">
+                        @csrf
+                        @method('DELETE')
+                        <button class="btn btn-danger" id="btn-exluir-finalidade" onclick="return confirm('Excluir a finalidade {{$finalidade->legenda}}?')"><i class="fa fa-trash" ></i></button>
+                    </form>
+                </li>
             @endforeach
         @else
             <li class="list-group-item">Não há finalidades cadastradas.</li>

--- a/resources/views/settings/partials/form.blade.php
+++ b/resources/views/settings/partials/form.blade.php
@@ -3,15 +3,13 @@
         <b>Configurações Gerais</b>
     </div>
     <div class="card-body">
-        <div class="row">
-            <div class="col-sm form-group">
-                <label for="" class="required"><b>Escolha a cor padrão para reservas</b></label>
-                <br>
-                <input type="color" class="form-control form-control-color" name="cor" value= "{{ old('cor', $cor) }}">
+            <div class="list-group list-group-flush">
+                <a class="list-group-item config-item rounded"  href="{{route('finalidades.index')}}">
+                    <div class="w-100 d-inline-flex justify-content-between align-items-center">
+                        Finalidades
+                        <i class="fas fa-chevron-right"></i>
+                    </div>
+                </a>
             </div>
-        </div>
-        <div class="row">
-            <button type="submit" class="btn btn-success"> Enviar </button>
-        </div>
     </div>
 </div>

--- a/resources/views/settings/show.blade.php
+++ b/resources/views/settings/show.blade.php
@@ -4,10 +4,16 @@
         @csrf
         @include('settings.partials.form')
     </form>
-    <div class="card mt-3">
-        <div class="card-header">Finalidades</div>
-        <div class="card-body">
-            <a class="btn btn-primary" href="{{route('finalidades.index')}}">Finalidades</a>
-        </div>
-    </div>
+@endsection
+
+@section('styles')
+@parent    
+<style>
+    .config-item{
+        color: inherit;
+    }
+    .config-item:hover{
+        background-color: rgba(207, 229, 255, 0.452);
+    }
+</style>
 @endsection

--- a/resources/views/settings/show.blade.php
+++ b/resources/views/settings/show.blade.php
@@ -4,4 +4,10 @@
         @csrf
         @include('settings.partials.form')
     </form>
+    <div class="card mt-3">
+        <div class="card-header">Finalidades</div>
+        <div class="card-body">
+            <a class="btn btn-primary" href="{{route('finalidades.index')}}">Finalidades</a>
+        </div>
+    </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\CategoriaController;
+use App\Http\Controllers\FinalidadeController;
 use App\Http\Controllers\GeneralSettingsController;
 use App\Http\Controllers\IndexController;
 use App\Http\Controllers\RecursoController;
@@ -40,3 +41,6 @@ Route::post('/settings', [GeneralSettingsController::class, 'update']);
 // Home
 Route::get('/', [IndexController::class, 'home'])->name('home');
 Route::get('/search', [IndexController::class, 'search']);
+
+// Finalidades
+Route::resource('finalidades', FinalidadeController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ Route::resource('/recursos', RecursoController::class)->only(['index', 'store', 
 // Categorias
 Route::resource('/categorias', CategoriaController::class)->except(['index']);
 Route::post('/categorias/adduser/{categoria}', [CategoriaController::class, 'addUser']);
+Route::post('/categorias/alterar-vinculos/{categoria}', [CategoriaController::class, 'alterarVinculos'])->name('alterar-vinculos');
 Route::delete('/categorias/removeuser/{categoria}/{user}', [CategoriaController::class, 'removeUser']);
 
 // Logs

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\GeneralSettingsController;
 use App\Http\Controllers\IndexController;
 use App\Http\Controllers\RecursoController;
 use App\Http\Controllers\ReservaController;
+use App\Http\Controllers\ResponsavelController;
 use App\Http\Controllers\SalaController;
 use Illuminate\Support\Facades\Route;
 
@@ -15,6 +16,9 @@ Route::resource('/reservas', ReservaController::class)->except(['index']);
 // Salas
 Route::resource('/salas', SalaController::class);
 Route::post('/salas/redirect', [SalaController::class, 'redirect']);
+
+// Responsáveis
+Route::resource('/responsaveis', ResponsavelController::class)->only(['store', 'destroy'])->parameters(['responsaveis' => 'responsavel']);
 
 // Recursos
 Route::resource('/recursos', RecursoController::class)->only(['index', 'store', 'destroy']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -43,4 +43,4 @@ Route::get('/', [IndexController::class, 'home'])->name('home');
 Route::get('/search', [IndexController::class, 'search']);
 
 // Finalidades
-Route::resource('finalidades', FinalidadeController::class);
+Route::resource('finalidades', FinalidadeController::class)->except(['show']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -33,5 +33,5 @@ Route::get('/settings', [GeneralSettingsController::class, 'show']);
 Route::post('/settings', [GeneralSettingsController::class, 'update']);
 
 // Home
-Route::get('/', [IndexController::class, 'home']);
+Route::get('/', [IndexController::class, 'home'])->name('home');
 Route::get('/search', [IndexController::class, 'search']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Route;
 
 // Reservas
 Route::get('/reservas/my', [ReservaController::class, 'my']);
+Route::get('/reservas/{reserva}/aprovar', [ReservaController::class, 'aprovar'])->name('reservas.aprovar');
 Route::resource('/reservas', ReservaController::class)->except(['index']);
 
 // Salas


### PR DESCRIPTION
Esta *pull request* foi pensada para adaptar as funcionalidades do sistema atual para as unidades que utilizam o sistema *Booked* de reservas. As seguintes implementações foram feitas:

## Cadastrando pessoas na categoria com base no vínculo:
Fix #97 

Agora, ao editar uma categoria, além de cadastrar as pessoas que poderão realizar reservas nesta categoria manualmente, através do número USP, também há três opções para controle com base no vínculo. São estes:

- **USP**: todos os servidores, docentes e estagiários que entrarem com a senha única no sistema poderão realizar reservas na categoria em questão.
- **Unidade**: todos os servidores, docentes e estagiários que entrarem com a senha única e forem da unidade que o sistema está configurado poderão realizar reservas na categoria em questão.
 (A unidade é mostrada com base na variável de ambiente `REPLICADO_CODUNDCLG` do `.env`)
- **Nenhum**: somente as pessoas cadastradas manualmente, através do número USP, poderão realizar reservas na categoria em questão.

As opções são referentes apenas ao vínculos de Docente, Servidor e Estagiário. Para pessoas com outro vínculo é necessário adicioná-las manualmente.

Para tal implementação foi necessário atualizar o pacote [uspdev/senhaunica-socialite](https://github.com/uspdev/senhaunica-socialite).

## Aprovação de reserva por responsável da sala: 
 Fix #94 
 Fix #98

Agora, ao editar uma sala, é possível configurar se as reservas feitas nesta sala deverão passar por aprovação dos responsáveis da sala ou não. Os responsáveis da sala são adicionados manualmente através do número USP na página de edição da sala. 

No caso da sala necessitar de aprovação, ao realizar uma reserva nesta sala esta ficará com o *status* de pendente, necessitando que um dos responsáveis pela sala entre no sistema e aprove ou recuse a reserva em questão, sendo que podem realizar esta ação acessando a reserva pelo calendário no sistema e a opção de aprovar ou recusar será mostrada.

Um e-mail é disparado para o solicitante e para todos os responsáveis da sala no momento de solicitar a reserva, avisando da pendência da reserva.

No caso da sala não necessitar de aprovação as reservas feitas na sala são automaticamente salvas com o *status* de aprovada.

Isto foi controlado adicionando uma coluna `aprovacao` na tabela `salas`, que determina se a sala necessita de aprovação ou não, e também adicionando uma coluna `status` na tabela `reservas`, que determina se a reserva está aprovada ou pendente.

## Finalidades para as reservas:

Uma nova tabela `finalidades` foi criada com a seguinte estrutura:

| finalidades |
|---------------|
| PK id|
| String legenda| 
| String cor |
| Date created_at |
| Date updated_at|

As finalidades podem ser administradas normalmente, adicionando, editando e excluindo, na aba de configurações do sistema. Sendo que ao subir o sistema as seguintes finalidades já são inseridas por padrão:

- Graduação
- Pós-Graduação
- Especialização
- Extensão
- Defesa
- Qualificação
- Reunião
- Evento

O campo `cor` foi removido da tabela `reservas` e foi substituído por uma *foreign key* para a tabela `finalidades` de nome `finalidade_id`.

Desta forma, ao realizar uma reserva agora deve-se selecionar uma finalidade, e assim, a reserva será mostrada com a cor e legenda da finalidade, como no exemplo a seguir:

![teste reserva](https://github.com/uspdev/salas/assets/47902146/56e88622-6b45-47e8-9a4f-4541dfd763b7)

Bem como no calendário:

![Captura de tela de 2023-10-19 11-16-46](https://github.com/uspdev/salas/assets/47902146/01a65841-cdd5-4dbb-b93d-323f13c71b8c)

As reservas pendentes (que esperam aprovação de um responsável da sala) serão sinalizadas como a legenda do calendário mostra, em laranja,  e ao serem aprovadas mostrarão a cor da finalidade da reserva. Na aba da reserva também é sinalizado quando uma reserva está pendente.

**Observação:** As reservas feitas anteriormente no sistema, após o *merge* desta implementação, aparecerão como 'Sem Finalidade' e com a cor cinza, como é possível observar na legenda do exemplo do calendário acima.

# Proposta para uma nova *release*

Como tais implementações modificam consideravelmente o sistema mas não afetam sua compatibilidade, deixo nesta *pull request* a sugestão de adicionar a *tag* de *release* **1.0.0** para o sistema atual, e após adicionar tais implementações à *master* adicionar a *tag* para uma nova *release* **1.1.0**.

