### PR TITLE
Atualizando e permitindo reservas pelo calendário

### DIFF
--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -71,37 +71,27 @@ class SalaController extends Controller
      */
     public function show(Sala $sala)
     {
-        // pegando as reservas das salas
-        $events = [];
 
         foreach ($sala->reservas as $reserva) {
-            $events[] = \Calendar::event(
-                $reserva->nome,
-                false, //full day event?
-                $reserva->inicio,
-                $reserva->fim,
-                0, //optionally, you can specify an event ID,
-                [
-                    'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? config('salas.cores.semFinalidade')),
-                    'url' => '/reservas/'.$reserva->id,
-                    'textColor' => 'black'
-                ],
-            );
-        }
 
-        $calendar = \Calendar::addEvents($events)
-            ->setOptions([
-                'firstDay' => 1,
-                'defaultView' => 'agendaWeek',
-        ]);
+            $eventos[] = [
+                'title' => $reserva->nome,
+                'start' => $reserva->inicio,
+                'end' => $reserva->fim,
+                'url' => route('reservas.show', $reserva->id),
+                'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? config('salas.cores.semFinalidade')),
+                'textColor' => 'black'
+            ];
+
+        }
 
         $finalidades = Finalidade::all();
 
         return view('sala.show', [
             'sala' => $sala,
-            'calendar' => $calendar,
             'recursos' => Recurso::all(),
-            'finalidades' => $finalidades
+            'finalidades' => $finalidades,
+            'eventos' => $eventos
             ]);
     }
 

--- a/resources/views/main.blade.php
+++ b/resources/views/main.blade.php
@@ -3,9 +3,7 @@
 @section('styles')
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.1/moment.min.js"></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/3.10.2/fullcalendar.min.js'></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/3.10.2/locale/pt-br.min.js'></script>
-    <link rel='stylesheet' href="https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/3.1.0/fullcalendar.min.css" />
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js"></script> 
     <link rel='stylesheet' href="{{ asset('assets/css/calendar.css') }}" />
     <link rel='stylesheet' href="{{ asset('assets/css/app.css') }}">
 @endsection

--- a/resources/views/reserva/partials/datetime-fields.blade.php
+++ b/resources/views/reserva/partials/datetime-fields.blade.php
@@ -2,18 +2,18 @@
     <div class="col-sm form-group">
         <label for="" class="required" ><b>Data</b></label>
         <br>
-        <input type="text" name="data" class="datepicker" value="{{  old('data', $reserva->data) }}">
+        <input type="text" name="data" class="datepicker" value="{{ $_GET["data"] ?? old('data', $reserva->data) }}">
     </div>
     <div class="col-sm form-group">
         <label for="" class="required"><b>Horário de início </b></label>
         <br>
-        <input class="form-control" type="text" name="horario_inicio" value="{{ old('horario_inicio', $reserva->horario_inicio) }}">
+        <input class="form-control" type="text" name="horario_inicio" value="{{ $_GET["start"] ?? old('horario_inicio', $reserva->horario_inicio) }}">
         <small class="form-text text-muted">Formato: 9:00 </small>
     </div>
     <div class="col-sm form-group">
         <label for="" class="required"><b>Horário de fim </b></label>
         <br>
-        <input class="form-control" type="text" name="horario_fim" value="{{ old('horario_fim', $reserva->horario_fim) }}">
+        <input class="form-control" type="text" name="horario_fim" value="{{ $_GET["end"] ?? old('horario_fim', $reserva->horario_fim) }}">
         <small class="form-text text-muted">Formato: 9:00 </small>
     </div>
     <div class="col-sm form-group">
@@ -25,7 +25,7 @@
               @foreach($categoria->salas as $sala)
                 @if( old('sala_id') == '' and isset($reserva->sala_id) )
                   <option value="{{ $sala->id }}" {{ ($reserva->sala_id ==
-                  $sala->id) ? 'selected' : '' }} >{{ $sala->nome }} [ Capacidade: {{
+                  $sala->id) || (isset($_GET['sala']) && $_GET['sala'] == $sala->id) ? 'selected' : '' }} >{{ $sala->nome }} [ Capacidade: {{
                     $sala->capacidade }} ]
                       @forelse($sala->recursos as $recurso)
                         @if ($loop->first)
@@ -41,7 +41,7 @@
                   </option>
                 @else
                   <option value="{{ $sala->id }}"
-                    {{ ( old('sala_id') == $sala->id ) ? 'selected' : '' }}>
+                    {{ ( old('sala_id') == $sala->id ) || (isset($_GET['sala']) && $_GET['sala'] == $sala->id) ? 'selected' : '' }}>
                     {{ $sala->nome }} [ Capacidade: {{ $sala->capacidade }} ]
                       @forelse($sala->recursos as $recurso)
                         @if ($loop->first)

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -50,20 +50,24 @@
                 timeGrid: {
                     selectable: true,
                     select: function(time){
-                        window.location.assign("{{route('reservas.create')}}"
-                            + "?data=" + time.start.toLocaleDateString('pt-BR') 
-                            + "&start=" + time.start.getHours() + ":" + (time.start.getMinutes() < 10 ? '0' : '') + time.start.getMinutes() 
-                            + "&end=" + time.end.getHours() + ":" + (time.end.getMinutes() < 10 ? '0' : '') + time.end.getMinutes() 
-                            + "&sala={{$sala->id}}");
+                        if (parseInt({{Gate::allows('members', $sala->id)}})) {
+                            window.location.assign("{{route('reservas.create')}}"
+                                + "?data=" + time.start.toLocaleDateString('pt-BR') 
+                                + "&start=" + time.start.getHours() + ":" + (time.start.getMinutes() < 10 ? '0' : '') + time.start.getMinutes() 
+                                + "&end=" + time.end.getHours() + ":" + (time.end.getMinutes() < 10 ? '0' : '') + time.end.getMinutes() 
+                                + "&sala={{$sala->id}}");
+                        }
                     }
                 },
 
                 dayGridMonth: {
                     selectable: true,
                     select: function(time){
-                        window.location.assign("{{route('reservas.create')}}"
-                        + "?data=" + time.start.toLocaleDateString('pt-BR')
-                        + "&sala={{$sala->id}}");
+                        if (parseInt({{Gate::allows('members', $sala->id)}})) {
+                            window.location.assign("{{route('reservas.create')}}"
+                            + "?data=" + time.start.toLocaleDateString('pt-BR')
+                            + "&sala={{$sala->id}}");
+                        }
                     }
                 }
             },

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -55,6 +55,15 @@
                             + "&end=" + time.end.getHours() + ":" + (time.end.getMinutes() < 10 ? '0' : '') + time.end.getMinutes() 
                             + "&sala={{$sala->id}}");
                     }
+                },
+
+                dayGridMonth: {
+                    selectable: true,
+                    select: function(time){
+                        window.location.assign("{{route('reservas.create')}}"
+                        + "?data=" + time.start.toLocaleDateString('pt-BR')
+                        + "&sala={{$sala->id}}");
+                    }
                 }
             },
             headerToolbar:{

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -45,6 +45,7 @@
             locale: 'pt-BR',
             expandRows: 'true',
             eventDisplay: 'block',
+            allDaySlot: false,
             views: {
                 timeGrid: {
                     selectable: true,
@@ -78,7 +79,6 @@
                 day:      'Dia',
                 list:     'Lista',
             },
-            allDayText: 'dia inteiro',
             events: {{Illuminate\Support\Js::from($eventos)}}
         });
 

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -45,6 +45,18 @@
             locale: 'pt-BR',
             expandRows: 'true',
             eventDisplay: 'block',
+            views: {
+                timeGrid: {
+                    selectable: true,
+                    select: function(time){
+                        window.location.assign("{{route('reservas.create')}}"
+                            + "?data=" + time.start.toLocaleDateString('pt-BR') 
+                            + "&start=" + time.start.getHours() + ":" + (time.start.getMinutes() < 10 ? '0' : '') + time.start.getMinutes() 
+                            + "&end=" + time.end.getHours() + ":" + (time.end.getMinutes() < 10 ? '0' : '') + time.end.getMinutes() 
+                            + "&sala={{$sala->id}}");
+                    }
+                }
+            },
             headerToolbar:{
                 left: 'prev,next today',
                 center: 'title',

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -19,9 +19,7 @@
             <div class="flex-item rounded" style="background-color: {{config('salas.cores.semFinalidade')}}">Sem Finalidade</div>
     </div>
 
-    <br><br>
-    {!! $calendar->calendar() !!}
-    {!! $calendar->script() !!}
+    <div id="calendar" class="mt-4"></div>
 @endsection  
 
 @section('styles')
@@ -34,4 +32,38 @@
         border: 1px solid black;
     }
 </style>
+@endsection
+
+@section('javascripts_bottom')
+   @parent
+   <script>
+
+        document.addEventListener('DOMContentLoaded', function() {
+        var calendarEl = document.getElementById('calendar');
+        var calendar = new FullCalendar.Calendar(calendarEl, {
+            initialView: 'timeGridWeek',
+            locale: 'pt-BR',
+            expandRows: 'true',
+            eventDisplay: 'block',
+            headerToolbar:{
+                left: 'prev,next today',
+                center: 'title',
+                right: 'dayGridMonth,timeGridWeek,timeGridDay'
+            },
+            buttonText: {
+                today:    'Hoje',
+                month:    'Mês',
+                week:     'Semana',
+                day:      'Dia',
+                list:     'Lista',
+            },
+            allDayText: 'dia inteiro',
+            events: {{Illuminate\Support\Js::from($eventos)}}
+        });
+
+
+        calendar.render();
+      });
+
+   </script>
 @endsection


### PR DESCRIPTION
### Atualização da biblioteca do calendário

A biblioteca [FullCalendar](https://fullcalendar.io/) foi atualizada para a versão atual, com base na documentação. E toda sua configuração está sendo feita na seção *javascripts_bottom* do blade, no arquivo `resources/views/sala/show.blade.php`. 

Os eventos para o calendário agora estão sendo configurados e enviados através de um *array* de *arrays* no método `show` da classe `SalaController`.

### Reservas pelo calendário

Agora é possível clicar e arrastar no calendário para selecionar um período de tempo que se deseja fazer uma nova reserva. Após selecionar, o usuário é direcionado para a página de realizar uma nova reserva com os campos Data, Horário de início, Horário de fim e Sala preenchidos com os dados selecionados no calendário. Sendo que a partir do calendário de mês, é preenchido somente os campo de Data e Sala.

A validação da reserva ainda é feita no momento de cadastro da reserva, portanto no momento de selecionar o período no calendário não é verificado se há conflito de reservas.

--------
Esta *pull request* foi pensada como um primeiro passo para atualizar todo o sistema para o Laravel 10. Visto que a implementação anterior do calendário gera conflitos nas dependências do composer para a versão mais recente do Laravel, com estas implementações será possível remover a biblioteca [uspdev/laravel-fullcalendar](https://github.com/uspdev/laravel-fullcalendar) das dependências para corrigir estes conflitos.