### PR TITLE
Verificação da data repeat_until para validar as reservas em repetição

### DIFF
--- a/resources/views/sala/partials/form.blade.php
+++ b/resources/views/sala/partials/form.blade.php
@@ -127,7 +127,7 @@
                     <br>Quantidade de dias de antecedência mínima para reservar a sala. Ao habilitar essa opção, o sistema não permite a reserva que não respeite o período mínimo de antecedência, mesmo que a sala esteja livre.
                     <div class="form-group">
                         <label for="dias_antecedencia">Dias de antecedência:</label>
-                        <input type="number" name="dias_antecedencia" value="{{ old('dias_antecedencia', $sala->restricao->dias_antecedencia) }}" min="1" max="99999">
+                        <input type="number" name="dias_antecedencia" value="{{ old('dias_antecedencia', $sala->restricao->dias_antecedencia) }}" min="0" max="99999">
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
A data "repeat_until" passa a ser verificada pelo validador para confirmar que, além da data da primeira reserva,  a última também esteja dentro das restrições definidas para a sala. 

Me parece que isso é suficiente e não é necessário passar cada reserva pelo validador.


closes #135