### PR TITLE
Incluindo responsáveis para as reservas

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -268,14 +268,52 @@ class ReservaController extends Controller
     {
         $this->authorize('owner', $reserva);
 
+        $validated = $request->validated();
+
+        $responsaveis = collect();
+
+        switch ($request->tipo_responsaveis) {
+            case 'eu':
+                $responsavel = ResponsavelReserva::firstOrCreate([
+                    'nome' => auth()->user()->name,
+                    'codpes' => auth()->user()->codpes
+                ]);
+                $responsaveis->push($responsavel);
+
+                break;
+            
+            case 'unidade':
+                foreach ($request->responsaveis_unidade as $responsavel_codpes) {
+                    $responsavel = ResponsavelReserva::firstOrCreate([
+                        'nome' => Pessoa::obterNome($responsavel_codpes),
+                        'codpes' => $responsavel_codpes
+                    ]);
+                    $responsaveis->push($responsavel);
+                }
+                
+                break;
+            
+            case 'externo':
+                foreach($request->responsaveis_externo as $responsavel_nome){
+                    $responsavel = ResponsavelReserva::firstOrCreate([
+                        'nome' => $responsavel_nome
+                    ]);
+                    $responsaveis->push($responsavel);
+                }
+
+                break;
+        }
+
+        $reserva->responsaveis()->sync($responsaveis->pluck('id'));
+
         // 1 - caso de edição de reserva sem repetições
         if(!isset($request->rep_bool) or empty($request->rep_bool)) {
-            $reserva->update($request->validated());
+            $reserva->update($validated);
         }
         
         // 2 - edição da reserva pai, caso com repeticões, entretanto, foi marcado Não, então as filhos serão excluídos
         if(isset($request->rep_bool) and $request->rep_bool=='Não') {
-            $reserva->update($request->validated());
+            $reserva->update($validated);
 
             foreach($reserva->children()->get() as $child) {
                 // não podemos apagar a reserva principal
@@ -294,7 +332,6 @@ class ReservaController extends Controller
 
         // 3 - edição da reserva pai, caso com repeticões, mas o padrão de repetição foi alterado
         if(isset($request->rep_bool) and $request->rep_bool=='Sim') {
-            $validated = $request->validated();
             $reserva->update($validated);
             // deletar as filhas antigas
             foreach($reserva->children()->get() as $child) {

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -84,7 +84,10 @@ class SalaController extends Controller
                 'end' => $reserva->fim,
                 'url' => route('reservas.show', $reserva->id),
                 'color' => $reserva->status == 'pendente' ? config('salas.cores.pendente') : ($reserva->finalidade->cor ?? config('salas.cores.semFinalidade')),
-                'textColor' => 'black'
+                'textColor' => 'black',
+                'extendedProps' => [
+                    'responsaveis'=> $reserva->responsaveis->pluck('nome')
+                ]
             ];
 
         }

--- a/app/Http/Requests/ReservaRequest.php
+++ b/app/Http/Requests/ReservaRequest.php
@@ -50,6 +50,7 @@ class ReservaRequest extends FormRequest
             'repeat_until' => ['required_with:repeat_days', 'nullable', 'date_format:d/m/Y'],
             'repeat_days.*' => 'integer|between:0,7',
             'data' => ['required', 'date_format:d/m/Y', new verifyRoomAvailability($this, $id)],
+            'tipo_responsaveis' => 'required'
         ];
 
         if(!Gate::allows('responsavel', Sala::find($this->sala_id))){

--- a/app/Models/Reserva.php
+++ b/app/Models/Reserva.php
@@ -107,4 +107,8 @@ class Reserva extends Model implements Auditable
     public function finalidade(){
         return $this->belongsTo(Finalidade::class);
     }
+    
+    public function responsaveis(){
+        return $this->belongsToMany(ResponsavelReserva::class);
+    }
 }

--- a/app/Models/Reserva.php
+++ b/app/Models/Reserva.php
@@ -109,6 +109,6 @@ class Reserva extends Model implements Auditable
     }
     
     public function responsaveis(){
-        return $this->belongsToMany(ResponsavelReserva::class);
+        return $this->belongsToMany(ResponsavelReserva::class, 'reservas_responsaveis_reservas', 'reserva_id', 'responsavel_reserva_id')->withTimestamps();
     }
 }

--- a/app/Models/ResponsavelReserva.php
+++ b/app/Models/ResponsavelReserva.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ResponsavelReserva extends Model
+{
+    use HasFactory;
+
+    public function reservas(){
+        return $this->belongsToMany(Reserva::class);
+    }
+}

--- a/app/Models/ResponsavelReserva.php
+++ b/app/Models/ResponsavelReserva.php
@@ -9,6 +9,9 @@ class ResponsavelReserva extends Model
 {
     use HasFactory;
 
+    protected $table = 'responsaveis_reservas';
+    protected $guarded = ['id'];
+
     public function reservas(){
         return $this->belongsToMany(Reserva::class);
     }

--- a/database/migrations/2023_12_12_111258_create_responsaveis_reservas_table.php
+++ b/database/migrations/2023_12_12_111258_create_responsaveis_reservas_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateResponsaveisReservasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('responsaveis_reservas', function (Blueprint $table) {
+            $table->id();
+            $table->string('nome');
+            $table->integer('codpes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('responsaveis_reservas');
+    }
+}

--- a/database/migrations/2023_12_12_111306_create_reservas_responsaveis_reservas_table.php
+++ b/database/migrations/2023_12_12_111306_create_reservas_responsaveis_reservas_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateReservasResponsaveisReservasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('reservas_responsaveis_reservas', function (Blueprint $table) {
+            $table->id();
+            $table->integer('reserva_id')->unsigned();
+            $table->foreign('reserva_id')->references('id')->on('reservas');
+            $table->foreignId('responsavel_reserva_id')->constrained('responsaveis_reservas');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('reservas_responsaveis_reservas');
+    }
+}

--- a/database/migrations/2023_12_12_111306_create_reservas_responsaveis_reservas_table.php
+++ b/database/migrations/2023_12_12_111306_create_reservas_responsaveis_reservas_table.php
@@ -16,8 +16,8 @@ class CreateReservasResponsaveisReservasTable extends Migration
         Schema::create('reservas_responsaveis_reservas', function (Blueprint $table) {
             $table->id();
             $table->integer('reserva_id')->unsigned();
-            $table->foreign('reserva_id')->references('id')->on('reservas');
-            $table->foreignId('responsavel_reserva_id')->constrained('responsaveis_reservas');
+            $table->foreign('reserva_id')->references('id')->on('reservas')->cascadeOnDelete();
+            $table->foreignId('responsavel_reserva_id')->constrained('responsaveis_reservas')->cascadeOnDelete();
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_12_12_113602_add_tipo_responsaveis_column_to_reservas_table.php
+++ b/database/migrations/2023_12_12_113602_add_tipo_responsaveis_column_to_reservas_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTipoResponsaveisColumnToReservasTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            $table->enum('tipo_responsaveis', ['eu', 'unidade', 'externo'])->default('eu');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('reservas', function (Blueprint $table) {
+            $table->dropColumn('tipo_responsaveis');
+        });
+    }
+}

--- a/resources/views/reserva/create.blade.php
+++ b/resources/views/reserva/create.blade.php
@@ -1,7 +1,7 @@
 @extends('main')
 
 @section('content')
-    <form method="POST" action="/reservas">
+    <form id="form-reserva" method="POST" action="/reservas" data-ajax="{{ route('SenhaunicaFindUsers') }}">
         @csrf
         @include('reserva.partials.form', ['title' => "Nova reserva"])
     </form>
@@ -42,4 +42,6 @@
         });
 
     </script>
+
+    @include('reserva.partials.select2-responsaveis-js')
 @stop

--- a/resources/views/reserva/edit.blade.php
+++ b/resources/views/reserva/edit.blade.php
@@ -1,7 +1,7 @@
 @extends('main')
 
 @section('content')
-    <form method="POST" action="/reservas/{{ $reserva->id }}">
+    <form id="form-reserva"  method="POST" action="/reservas/{{ $reserva->id }}" data-ajax="{{ route('SenhaunicaFindUsers') }}">
         @csrf
         @method('patch')
         @include('reserva.partials.form', ['title' => "Editar reserva"])
@@ -43,4 +43,6 @@
         });
 
     </script>
+
+    @include('reserva.partials.select2-responsaveis-js')
 @stop

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -67,7 +67,7 @@
                 </tr>
                 <tr>
                     <td>{{ $reserva->user->name }} - {{ $reserva->user->codpes }}</td>
-                    <td>{{$reserva->responsaveis->pluck('nome')->implode(', ')}}</td>
+                    <td>{{$reserva->responsaveis->count() > 0 ? $reserva->responsaveis->pluck('nome')->implode(', ') : 'Sem responsáveis'}}</td>
                     <td>{{ $reserva->data }}</td>
                     <td>{{ $reserva->horario_inicio }} a {{ $reserva->horario_fim }}</td>
                     <td>

--- a/resources/views/reserva/partials/fields.blade.php
+++ b/resources/views/reserva/partials/fields.blade.php
@@ -58,6 +58,7 @@
             <div class="table-responsive">
                 <tr>
                     <th>Cadastrada por</th>
+                    <th>Responsáveis</th>
                     <th>Data</th>
                     <th>Horário</th>
                     <th>Sala</th>
@@ -66,6 +67,7 @@
                 </tr>
                 <tr>
                     <td>{{ $reserva->user->name }} - {{ $reserva->user->codpes }}</td>
+                    <td>{{$reserva->responsaveis->pluck('nome')->implode(', ')}}</td>
                     <td>{{ $reserva->data }}</td>
                     <td>{{ $reserva->horario_inicio }} a {{ $reserva->horario_fim }}</td>
                     <td>

--- a/resources/views/reserva/partials/form.blade.php
+++ b/resources/views/reserva/partials/form.blade.php
@@ -57,15 +57,26 @@
         </div>
         <div class="add-responsavel-unidade mb-3">
             <select name="responsaveis_unidade[]" class="form-control form-control-sm" multiple="multiple" data-placeholder="Buscar pessoa">
-                @foreach ($reserva->responsaveis as $responsavel)
-                    <option value="{{$responsavel->codpes}}" selected="seleted">{{$responsavel->codpes}} {{$responsavel->nome}}</option>   
-                @endforeach
+                @if ($reserva->tipo_responsaveis == 'unidade')
+                    @foreach ($reserva->responsaveis as $responsavel)
+                        <option value="{{$responsavel->codpes}}" selected="seleted">{{$responsavel->codpes}} {{$responsavel->nome}}</option>   
+                    @endforeach
+                @endif
             </select>
         </div>
 
         <div class="add-responsavel-externo mb-3">
-            <input type="text" name="responsaveis_externo[]" class="form-control mb-2" placeholder="Nome completo do responsável..." value="{{old('tipo_responsaveis', $reserva->tipo_responsaveis) == 'externo' ? old('responsaveis_externo', $reserva->responsaveis) : ''}}">
-            <a class="btn btn-primary btn-sm" id="btn-add-responsavel-externo-input"><i class="fas fa-plus-circle"></i> Adicionar mais um responsável</a>
+            @if ($reserva->tipo_responsaveis == 'externo')
+                @foreach ($reserva->responsaveis as $responsavel)
+                    <input type="text" name="responsaveis_externo[]" class="form-control mb-2" placeholder="Nome completo do responsável..." value="{{$responsavel->nome}}">
+                @endforeach
+            @else
+                <input type="text" name="responsaveis_externo[]" class="form-control mb-2" placeholder="Nome completo do responsável..." value="">
+            @endif
+            @if (count($reserva->responsaveis) < 3)
+                <a class="btn btn-primary btn-sm" id="btn-add-responsavel-externo-input"><i class="fas fa-plus-circle"></i> Adicionar mais um responsável</a>
+            @endif
+            <a class="btn btn-secondary btn-sm" id="btn-limpar-responsaveis-externo-input"><i class="fas fa-eraser"></i> Apagar responsáveis</a>
         </div>
 
         <div class="row">

--- a/resources/views/reserva/partials/form.blade.php
+++ b/resources/views/reserva/partials/form.blade.php
@@ -70,12 +70,12 @@
                 @foreach ($reserva->responsaveis as $responsavel)
                     <input type="text" name="responsaveis_externo[]" class="form-control mb-2" placeholder="Nome completo do responsável..." value="{{$responsavel->nome}}">
                 @endforeach
+                <a class="btn btn-primary btn-sm" id="btn-add-responsavel-externo-input" @if(count($reserva->responsaveis) > 2) style="display: none" @endif><i class="fas fa-plus-circle"></i> Adicionar mais um responsável</a>
             @else
                 <input type="text" name="responsaveis_externo[]" class="form-control mb-2" placeholder="Nome completo do responsável..." value="">
-            @endif
-            @if (count($reserva->responsaveis) < 3)
                 <a class="btn btn-primary btn-sm" id="btn-add-responsavel-externo-input"><i class="fas fa-plus-circle"></i> Adicionar mais um responsável</a>
             @endif
+
             <a class="btn btn-secondary btn-sm" id="btn-limpar-responsaveis-externo-input"><i class="fas fa-eraser"></i> Apagar responsáveis</a>
         </div>
 

--- a/resources/views/reserva/partials/form.blade.php
+++ b/resources/views/reserva/partials/form.blade.php
@@ -38,6 +38,38 @@
 
         <div class="row">
             <div class="col-sm form-group">
+                <b>Responsáveis pela reserva</b>
+                <div class="mt-2">
+                    <div class="form-check form-check-inline">
+                        <input id="eu" value="eu" class="form-check-input radio-eu" type="radio" name="tipo_responsaveis" role="button" {{old('tipo_responsaveis', $reserva->tipo_responsaveis) == 'eu' ? 'checked' : ''}}>
+                        <label for="eu" class="form-check-label radio-eu" role="button">Eu</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input id="unidade" value="unidade" class="form-check-input" type="radio" name="tipo_responsaveis" role="button" {{old('tipo_responsaveis', $reserva->tipo_responsaveis) == 'unidade' ? 'checked' : ''}}>
+                        <label for="unidade" class="form-check-label" role="button">Pessoas da unidade</label>
+                    </div>
+                    <div class="form-check form-check-inline">
+                        <input id="externo" value="externo" class="form-check-input" type="radio" name="tipo_responsaveis" role="button" {{old('tipo_responsaveis', $reserva->tipo_responsaveis) == 'externo' ? 'checked' : ''}}>
+                        <label for="externo" class="form-check-label" role="button">Pessoas externas</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="add-responsavel-unidade mb-3">
+            <select name="responsaveis_unidade[]" class="form-control form-control-sm" multiple="multiple" data-placeholder="Buscar pessoa">
+                @foreach ($reserva->responsaveis as $responsavel)
+                    <option value="{{$responsavel->codpes}}" selected="seleted">{{$responsavel->codpes}} {{$responsavel->nome}}</option>   
+                @endforeach
+            </select>
+        </div>
+
+        <div class="add-responsavel-externo mb-3">
+            <input type="text" name="responsaveis_externo[]" class="form-control mb-2" placeholder="Nome completo do responsável..." value="{{old('tipo_responsaveis', $reserva->tipo_responsaveis) == 'externo' ? old('responsaveis_externo', $reserva->responsaveis) : ''}}">
+            <a class="btn btn-primary btn-sm" id="btn-add-responsavel-externo-input"><i class="fas fa-plus-circle"></i> Adicionar mais um responsável</a>
+        </div>
+
+        <div class="row">
+            <div class="col-sm form-group">
                 <label for="" class="required"><b>Descrição</b></label>
                 <br>
                 <textarea name="descricao" class="form-control" rows="3">{{  old('descricao', $reserva->descricao) }}</textarea>

--- a/resources/views/reserva/partials/select2-responsaveis-js.blade.php
+++ b/resources/views/reserva/partials/select2-responsaveis-js.blade.php
@@ -1,0 +1,77 @@
+<script>
+    $(document).ready(function(){
+        var addResponsavelUnidade = $('.add-responsavel-unidade');
+        var addResponsavelExterno = $('.add-responsavel-externo');
+        var $oSelect2 = addResponsavelUnidade.find(":input[name='responsaveis_unidade[]']");
+        var selectExterno = addResponsavelExterno.find(":input[name='responsaveis_externo[]']");
+        var dataAjax = $('#form-reserva').data("ajax");
+
+        $('#btn-add-responsavel-externo-input').on('click', function(){
+            if($(":input[name='responsaveis_externo[]']").length < 2){
+                selectExterno.clone().prependTo(addResponsavelExterno).val("");
+            }else{
+                selectExterno.clone().prependTo(addResponsavelExterno).val("");
+                $(this).css('display', 'none');
+            }
+        });
+
+        $('[name=tipo_responsaveis]').on('change', function(e){
+            switch (e.target.value) {
+                case 'eu':
+                    addResponsavelUnidade.css('display', 'none');
+                    addResponsavelExterno.attr('style', 'display: none !important');
+                    $oSelect2.attr('required', false);
+                    selectExterno.attr('required', false);
+                    break;
+            
+                case 'unidade': 
+                    addResponsavelExterno.attr('style', 'display: none !important');
+                    addResponsavelUnidade.css('display', 'block');
+                    $oSelect2.attr('required', true);
+                    selectExterno.attr('required', false);
+                    break;
+
+                case 'externo': 
+                    addResponsavelExterno.attr('style', 'display: block !important');
+                    addResponsavelUnidade.css('display', 'none');
+                    $oSelect2.attr('required', false);
+                    selectExterno.attr('required', true);
+                    break;
+            }
+        });
+
+        $oSelect2.select2({
+            ajax: {
+                url: dataAjax,
+                dataType: 'json',
+                delay: 1000
+            },
+            maximumSelectionLength: 3,
+            placeholder: function() {
+                $(this).data('placeholder');
+            },
+            dropdownParent: addResponsavelUnidade,
+            minimumInputLength: 4,
+            theme: 'bootstrap4',
+            width: 'resolve',
+            language: 'pt-BR'
+        });
+
+        switch ('{{old('tipo_responsaveis', $reserva->tipo_responsaveis)}}') {
+            case 'eu':
+                addResponsavelUnidade.css('display', 'none');
+                addResponsavelExterno.attr('style', 'display: none !important');
+                break;
+        
+            case 'unidade':
+                addResponsavelExterno.attr('style', 'display: none !important');
+                $oSelect2.attr('required', true);
+                break;
+
+            case 'externo':
+                addResponsavelUnidade.css('display', 'none');
+                selectExterno.attr('required', true);
+                break;
+        }
+    });
+</script>

--- a/resources/views/reserva/partials/select2-responsaveis-js.blade.php
+++ b/resources/views/reserva/partials/select2-responsaveis-js.blade.php
@@ -8,11 +8,17 @@
 
         $('#btn-add-responsavel-externo-input').on('click', function(){
             if($(":input[name='responsaveis_externo[]']").length < 2){
-                selectExterno.clone().prependTo(addResponsavelExterno).val("");
+                selectExterno.first().clone().prependTo(addResponsavelExterno).val("");
             }else{
-                selectExterno.clone().prependTo(addResponsavelExterno).val("");
+                selectExterno.first().clone().prependTo(addResponsavelExterno).val("");
                 $(this).css('display', 'none');
             }
+        });
+
+        $('#btn-limpar-responsaveis-externo-input').on('click', function(){
+            addResponsavelExterno.find(":input[name='responsaveis_externo[]']").remove();
+            selectExterno.first().clone().prependTo(addResponsavelExterno).val("");
+            $('#btn-add-responsavel-externo-input').css('display', 'inline-block');
         });
 
         $('[name=tipo_responsaveis]').on('change', function(e){

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -62,6 +62,26 @@
             views: {
                 timeGrid: {
                     selectable: true,
+                    eventContent: function(info){
+                        let div = document.createElement('div');
+                        let eventTime = document.createElement('div');
+                        let start = new Date(info.event.start);
+                        let end = new Date(info.event.end);
+
+                        let horarioDeInicio = ("0" + start.getHours()).slice(-2) + ':' + ("0" + start.getMinutes()).slice(-2);
+                        let horarioDeFim = ("0" + end.getHours()).slice(-2) + ':' + ("0" + end.getMinutes()).slice(-2);
+
+                        let nomesResponsaveis = info.event.extendedProps.responsaveis.join(', ');
+
+                        eventTime.classList.add('fc-event-time');
+                        eventTime.innerHTML = horarioDeInicio + ' - ' + horarioDeFim;
+
+                        div.innerHTML =  info.event.title + '<br>' + nomesResponsaveis;
+
+                        let arrayDomNodes = [eventTime, div];
+
+                        return {domNodes: arrayDomNodes};
+                    },
                     select: function(time){
                         if (parseInt({{Gate::allows('members', $sala->id)}})) {
                             window.location.assign("{{route('reservas.create')}}"
@@ -75,6 +95,23 @@
 
                 dayGridMonth: {
                     selectable: true,
+                    eventContent: function(info){
+                        let bold = document.createElement('b');
+                        let div = document.createElement('div');
+                        let start = new Date(info.event.start);
+                        let horarioDeInicio = ("0" + start.getHours()).slice(-2) + ':' + ("0" + start.getMinutes()).slice(-2);
+
+                        let nomesResponsaveis = info.event.extendedProps.responsaveis.join(', ');
+
+                        bold.innerHTML = horarioDeInicio; 
+
+                        div.innerHTML = info.event.title + '<br>' + nomesResponsaveis;
+                        div.classList.add('text-wrap');
+
+                        let arrayDomNodes = [bold, div]
+
+                        return {domNodes: arrayDomNodes};
+                    },
                     select: function(time){
                         if (parseInt({{Gate::allows('members', $sala->id)}})) {
                             window.location.assign("{{route('reservas.create')}}"


### PR DESCRIPTION
Fix #113 

Agora no momento de cadastrar uma reserva é possível selecionar até três pessoas como responsáveis da reserva. Para este fim três opções são mostradas no momento da reserva:
- **Eu**: o responsável da sala ficará guardado como o usuário que está logado no momento do cadastro da reserva.
- **Unidade**: um campo do tipo *select2* que permite buscar e selecionar até três pessoas da unidade determinada pela variável de ambiente `SENHAUNICA_CODIGO_UNIDADE`, se utilizando da biblioteca [uspdev/senhaunica-socialite](https://github.com/uspdev/senhaunica-socialite).
- **Externo**: campos onde é possível inserir o nome de até três pessoas externas à unidade ou à universidade.

Para cada reserva, os responsáveis serão mostrados no calendário e momento de visualizar a reserva.