### PR TITLE
Mostrando aviso para sala bloqueadas no calendário

### DIFF
--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <div class="card">
         <div class="card-header" type="button" data-toggle="collapse" data-target="#collapse{{ $sala->id }}" aria-expanded="false" aria-controls="collapse{{ $sala->id }}">
-                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada ?? false)<span class="badge badge-warning ml-2">Sala Bloqueada</span>@endif</h4>
+                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada ?? false)<span class="badge badge-warning ml-2">Sala Bloqueada</span><span class="badge badge-warning ml-2">Motivo do bloqueio: {{$sala->restricao->motivo_bloqueio}}</span>@endif</h4>
             <i class="far fa-plus-square"></i>
         </div>
     </div>
@@ -11,10 +11,6 @@
             @include('sala.partials.fields')
         </div>
     </div>
-
-    @if ($sala->restricao->motivo_bloqueio ?? false)
-        <div class="alert alert-warning mt-2">Motivo do bloqueio: {{$sala->restricao->motivo_bloqueio}}</div>
-    @endif
 
     <div class="d-flex flex-wrap w-100 justify-content-center mt-3">
         @foreach ($finalidades as $finalidade)

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <div class="card">
         <div class="card-header" type="button" data-toggle="collapse" data-target="#collapse{{ $sala->id }}" aria-expanded="false" aria-controls="collapse{{ $sala->id }}">
-                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada)<span class="badge badge-warning ml-2">Sala Bloqueada</span>@endif</h4>
+                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada ?? false)<span class="badge badge-warning ml-2">Sala Bloqueada</span>@endif</h4>
             <i class="far fa-plus-square"></i>
         </div>
     </div>
@@ -53,7 +53,7 @@
             eventDisplay: 'block',
             allDaySlot: false,
             selectAllow: function(info){
-                @if($sala->restricao->bloqueada)
+                @if($sala->restricao->bloqueada ?? false)
                     return false;
                 @endif
 

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <div class="card">
         <div class="card-header" type="button" data-toggle="collapse" data-target="#collapse{{ $sala->id }}" aria-expanded="false" aria-controls="collapse{{ $sala->id }}">
-                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada ?? false)<span class="badge badge-warning ml-2">Sala Bloqueada</span><span class="badge badge-warning ml-2">Motivo do bloqueio: {{$sala->restricao->motivo_bloqueio}}</span>@endif</h4>
+                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada ?? false)<span class="badge badge-warning ml-2">Sala Bloqueada. Motivo: {{$sala->restricao->motivo_bloqueio}}</span>@endif</h4>
             <i class="far fa-plus-square"></i>
         </div>
     </div>

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -2,7 +2,7 @@
 @section('content')
     <div class="card">
         <div class="card-header" type="button" data-toggle="collapse" data-target="#collapse{{ $sala->id }}" aria-expanded="false" aria-controls="collapse{{ $sala->id }}">
-            <span><b>{{ $sala->nome }}</b></span>
+                <h4 class="m-0 d-flex align-items-center">{{$sala->nome}} @if($sala->restricao->bloqueada)<span class="badge badge-warning ml-2">Sala Bloqueada</span>@endif</h4>
             <i class="far fa-plus-square"></i>
         </div>
     </div>
@@ -53,6 +53,10 @@
             eventDisplay: 'block',
             allDaySlot: false,
             selectAllow: function(info){
+                @if($sala->restricao->bloqueada)
+                    return false;
+                @endif
+
                 if(parseInt({{Gate::allows('responsavel', App\Models\Sala::find($sala->id))}}))
                     return true;
                 if (info.start < Date.now())

--- a/resources/views/sala/show.blade.php
+++ b/resources/views/sala/show.blade.php
@@ -11,6 +11,11 @@
             @include('sala.partials.fields')
         </div>
     </div>
+
+    @if ($sala->restricao->motivo_bloqueio ?? false)
+        <div class="alert alert-warning mt-2">Motivo do bloqueio: {{$sala->restricao->motivo_bloqueio}}</div>
+    @endif
+
     <div class="d-flex flex-wrap w-100 justify-content-center mt-3">
         @foreach ($finalidades as $finalidade)
             <div class="flex-item rounded" style="background-color: {{$finalidade->cor}}">{{$finalidade->legenda}}</div>


### PR DESCRIPTION
Fix #142 

É mostrado uma _badge_ ao lado do nome da sala no calendário alertando se a sala estiver bloqueada. Também não é mais possível clicar no calendário para realizar uma reserva nas salas que estiverem bloqueadas.