### PR TITLE
Mudando coluna "aprovacao" da entidade "Sala" para entidade "Restricao"

### DIFF
--- a/app/Http/Controllers/ReservaController.php
+++ b/app/Http/Controllers/ReservaController.php
@@ -107,7 +107,7 @@ class ReservaController extends Controller
 
         $this->authorize('members', $validated['sala_id']);
 
-        if(Sala::find($validated['sala_id'])->aprovacao)
+        if(Sala::find($validated['sala_id'])->restricao->aprovacao)
         {
             $validated['status'] = 'pendente';
             $mensagem = "Reserva(s) enviada(s) para análise com sucesso.";

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -31,7 +31,7 @@ class ResponsavelController extends Controller
         $responsavel->user_id = $user->id;
         $responsavel->save();
 
-        $sala->aprovacao = 1;
+        $sala->restricao->aprovacao = 1;
         $sala->save();
 
         return redirect()->route('salas.edit',['sala' => $request->input('sala'), 'responsaveis' => $sala->responsaveis])->with('alert-success', $user->name.' adicionado como responsável.');
@@ -42,7 +42,7 @@ class ResponsavelController extends Controller
 
         // Se tiver apenas um responsável altera a sala para não precisar de aprovação ao deletar este único responsável.
         if(count($responsavel->sala->responsaveis) == 1){
-            $responsavel->sala->aprovacao = 0;
+            $responsavel->sala->restricao->aprovacao = 0;
             $responsavel->sala->save();
         }
 

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -174,7 +174,8 @@ class SalaController extends Controller
                 'dias_limite'          => $validated['dias_limite'],
                 'duracao_minima'       => $validated['duracao_minima'],
                 'duracao_maxima'       => $validated['duracao_maxima'],
-                'periodo_letivo_id'    => $validated['periodo_letivo']
+                'periodo_letivo_id'    => $validated['periodo_letivo'],
+                'aprovacao'            => $validated['aprovacao']
             ]
             );
         

--- a/app/Models/Restricao.php
+++ b/app/Models/Restricao.php
@@ -25,7 +25,7 @@ class Restricao extends Model
         'bloqueada',
         'sala_id',
         'periodo_letivo_id',
-        
+        'aprovacao'
 
     ];
 

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -115,10 +115,10 @@ class AuthServiceProvider extends ServiceProvider
             if(Gate::allows('admin')) return true;
 
             // Se a sala não necessita de aprovação retorna true.
-            if(!$reserva->sala->aprovacao) return true;
+            if(!$reserva->sala->restricao->aprovacao) return true;
 
             // Se a sala necessita de aprovação e está pendente retorna true.
-            if($reserva->sala->aprovacao && $reserva->status == 'pendente') return true;
+            if($reserva->sala->restricao->aprovacao && $reserva->status == 'pendente') return true;
 
             return false;
         });

--- a/database/migrations/2023_12_19_130910_change_aprovacao_column_to_restricoes_table.php
+++ b/database/migrations/2023_12_19_130910_change_aprovacao_column_to_restricoes_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeAprovacaoColumnToRestricoesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('salas', function (Blueprint $table) {
+            $table->dropColumn('aprovacao');
+        });
+
+
+        Schema::table('restricoes', function (Blueprint $table) {
+            $table->tinyInteger('aprovacao')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('salas', function (Blueprint $table) {
+            $table->tinyInteger('aprovacao')->default(0);
+        });
+
+
+        Schema::table('restricoes', function (Blueprint $table) {
+            $table->dropColumn('aprovacao');
+        });
+    }
+}

--- a/resources/views/sala/partials/form.blade.php
+++ b/resources/views/sala/partials/form.blade.php
@@ -54,14 +54,14 @@
                 <div class="col-sm form-group">
                     <b>Necessita de aprovação?</b>
                     <div class="form-check">
-                        <input name="aprovacao" type="radio" class="form-check-input radio-aprovacao" id="aprovacao-sim" value="1" {{$sala->aprovacao ? 'checked' : ''}}>
+                        <input name="aprovacao" type="radio" class="form-check-input radio-aprovacao" id="aprovacao-sim" value="1" {{$sala->restricao->aprovacao ? 'checked' : ''}}>
                         <label for="aprovacao-sim">Sim</label>
                     </div>
                     <div class="form-check">
-                        <input name="aprovacao" type="radio" class="form-check-input radio-aprovacao" id="aprovacao-nao" value="0" {{!$sala->aprovacao ? 'checked' : ''}}>
+                        <input name="aprovacao" type="radio" class="form-check-input radio-aprovacao" id="aprovacao-nao" value="0" {{!$sala->restricao->aprovacao ? 'checked' : ''}}>
                         <label for="aprovacao-nao">Não</label>
                     </div>
-                    <div id="responsavel-box" @if (!$sala->aprovacao) style="display: none" @endif>
+                    <div id="responsavel-box" @if (!$sala->restricao->aprovacao) style="display: none" @endif>
                         <b>Responsáveis</b>
                         <div class="d-flex flex-inline form-group">
                             <input name="codpes" type="text" placeholder="Número USP" class="w-25 form-control" id="numero-usp" form="form-add-responsavel" required> 


### PR DESCRIPTION
A coluna `aprovacao` foi removida da tabela `salas` e transferida para a tabela `restricoes`.

A mudança parece ser condizente visto que a determinação de precisar ou não de aprovação para realizar reservas na sala age como uma restrição para a sala em questão.

Fix #130