### PR TITLE
correção de bug na atualização da tabela restricoes; criação de variável de configuração

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,9 @@ SENHAUNICA_ADMINS=
 # Código da unidade para identificar os logins próprios ou de outras unidades
 SENHAUNICA_CODIGO_UNIDADE=
 
+# indica qual o nível de autorização necessário para se consultar pessoas da USP
+SENHAUNICA_FINDUSERSGATE=
+
 USP_THEME_SKIN=fflch
 
 # LARAVEL TOOLS #########################################

--- a/app/Http/Controllers/ResponsavelController.php
+++ b/app/Http/Controllers/ResponsavelController.php
@@ -32,6 +32,7 @@ class ResponsavelController extends Controller
         $responsavel->save();
 
         $sala->restricao->aprovacao = 1;
+        $sala->restricao->save();                     // sem isso, o registro na tabela restricoes não é atualizado, ainda que haja a linha a seguir
         $sala->save();
 
         return redirect()->route('salas.edit',['sala' => $request->input('sala'), 'responsaveis' => $sala->responsaveis])->with('alert-success', $user->name.' adicionado como responsável.');
@@ -43,6 +44,7 @@ class ResponsavelController extends Controller
         // Se tiver apenas um responsável altera a sala para não precisar de aprovação ao deletar este único responsável.
         if(count($responsavel->sala->responsaveis) == 1){
             $responsavel->sala->restricao->aprovacao = 0;
+            $responsavel->sala->restricao->save();    // sem isso, o registro na tabela restricoes não é atualizado, ainda que haja a linha a seguir
             $responsavel->sala->save();
         }
 

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Support\Facades\Log;/////////////////////////////////////////////////////////////////////////////////////////////////
-
 use App\Http\Requests\SalaRequest;
 use App\Models\Categoria;
 use App\Models\Finalidade;

--- a/app/Http/Controllers/SalaController.php
+++ b/app/Http/Controllers/SalaController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Support\Facades\Log;/////////////////////////////////////////////////////////////////////////////////////////////////
+
 use App\Http\Requests\SalaRequest;
 use App\Models\Categoria;
 use App\Models\Finalidade;
@@ -159,6 +161,14 @@ class SalaController extends Controller
             return redirect()->route('salas.edit', ['sala' => $sala->id])->with('alert-danger', 'A sala deve ter ao menos um responsável se necessitar de aprovação para reserva.');
 
         $sala->update($validated);
+
+        if (!$validated['aprovacao'] && count($sala->responsaveis) > 0) {
+            $responsavel_ids = [];
+            foreach($sala->responsaveis as $responsavel) {
+                $responsavel_ids[] = $responsavel->id;
+            }
+            $sala->responsaveis()->detach($responsavel_ids);
+        }
 
         if(array_key_exists('recursos', $validated)) {
             $sala->recursos()->sync($validated['recursos']);


### PR DESCRIPTION
1) Correção: não perde atualização na tabela restricoes quando o usuário adiciona/remove responsáveis no momento da edição de uma sala;
2) Correção: remove registros da tabela recurso_sala quando o usuário altera a sala, informando que ela não necessita de aprovação;
3) Cria variável de configuração "SENHAUNICA_FINDUSERSGATE" no .env.example para não administradores também poderem consultar pessoas da unidade no momento da criação de uma reserva de sala (esta funcionalidade está parcialmente prevista no senhaunica-socialite, mas não totalmente.... então fiz também um PR no senhaunica-socialite)